### PR TITLE
33 add unit tests for api controllers

### DIFF
--- a/ChasmaWebApi.Tests/ChasmaWebApi.Tests.csproj
+++ b/ChasmaWebApi.Tests/ChasmaWebApi.Tests.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest" Version="3.6.4" />
   </ItemGroup>
 

--- a/ChasmaWebApi.Tests/Controllers/ControllerTestBase.cs
+++ b/ChasmaWebApi.Tests/Controllers/ControllerTestBase.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace ChasmaWebApi.Tests.Controllers
+{
+    /// <summary>
+    /// Class representing the base class for controller tests.
+    /// </summary>
+    /// <typeparam name="T">The type of API controller base that is being tested.</typeparam>
+    public class ControllerTestBase<T>
+        where T : ControllerBase
+    {
+        /// <summary>
+        /// The full name of the test user.
+        /// </summary>
+        protected const string TestUserFullName = "Test User";
+
+        /// <summary>
+        /// The username of the test user.
+        /// </summary>
+        protected const string TestUserName = "testUser";
+
+        /// <summary>
+        /// The password of the test user.
+        /// </summary>
+        protected const string TestUserPassword = "password";
+
+        /// <summary>
+        /// The email of the test user.
+        /// </summary>
+        protected const string TestUserEmail = "test.user@email.com";
+
+        /// <summary>
+        /// The name of the test repository.
+        /// </summary>
+        protected const string TestRepositoryName = "TestRepository";
+
+        /// <summary>
+        /// The test instance of the <see cref="ControllerBase"/>.
+        /// </summary>
+        protected T Controller;
+
+        /// <summary>
+        /// Extracts the inner response from the action result task.
+        /// </summary>
+        /// <typeparam name="T">The type of response to retrieve.</typeparam>
+        /// <param name="task">The task containing the response.</param>
+        /// <param name="objectType">The type of action of result.</param>
+        /// <returns>The inner response.</returns>
+        protected static T ExtractActionResultInnerResponseFromTask<T>(Task<ActionResult<T>> task, Type objectType)
+        {
+            ActionResult<T> actionResult = task.Result;
+            if (actionResult?.Result == null)
+            {
+                throw new NullReferenceException("Cannot extract inner result because the action result is null.");
+            }
+
+            return ExtractActionResultInnerResponseFromActionResult(actionResult, objectType);
+        }
+
+        /// <summary>
+        /// Extracts the inner response from the action result.
+        /// </summary>
+        /// <typeparam name="T">The type of response to retrieve.</typeparam>
+        /// <param name="task">The task containing the response.</param>
+        /// <param name="objectType">The type of action of result.</param>
+        /// <returns>The inner response.</returns>
+        protected static T ExtractActionResultInnerResponseFromActionResult<T>(ActionResult<T> actionResult, Type objectType)
+        {
+            if (objectType == null)
+            {
+                throw new NullReferenceException("Cannot extract inner result because object result type is null.");
+            }
+
+            if (actionResult.Result == null)
+            {
+                throw new NullReferenceException("Cannot extract inner result because object result null.");
+            }
+
+            ObjectResult innerObjectResult;
+            if (objectType == typeof(OkObjectResult))
+            {
+                innerObjectResult = actionResult.Result as OkObjectResult;
+            }
+            else if (objectType == typeof(BadRequestObjectResult))
+            {
+                innerObjectResult = actionResult.Result as BadRequestObjectResult;
+            }
+            else
+            {
+                throw new ArgumentException("The object type specified is not implemented.");
+            }
+
+            return (T)innerObjectResult.Value;
+        }
+    }
+}

--- a/ChasmaWebApi.Tests/Controllers/HealthControllerTests.cs
+++ b/ChasmaWebApi.Tests/Controllers/HealthControllerTests.cs
@@ -1,0 +1,65 @@
+﻿using ChasmaWebApi.Controllers;
+using ChasmaWebApi.Data.Messages;
+using ChasmaWebApi.Data.Objects;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace ChasmaWebApi.Tests.Controllers
+{
+    /// <summary>
+    /// Class testing the functionality of the <see cref="HealthController"/> class.
+    /// </summary>
+    [TestClass]
+    public class HealthControllerTests : ControllerTestBase<HealthController>
+    {
+
+        /// <summary>
+        /// The mocked internal logger for API testing.
+        /// </summary>
+        private readonly Mock<ILogger<HealthController>> loggerMock;
+
+        #region Constructor
+
+        /// <summary>
+        /// Instantiates a new <see cref="HealthControllerTests"/> class.
+        /// </summary>
+        public HealthControllerTests()
+        {
+            loggerMock = new Mock<ILogger<HealthController>>();
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Sets up resources before each test.
+        /// </summary>
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            Controller = new HealthController(loggerMock.Object);
+        }
+
+        /// <summary>
+        /// Disposes of test resources after each test.
+        /// </summary>
+        [TestCleanup]
+        public void CleanupTests()
+        {
+            loggerMock.Reset();
+        }
+
+        /// <summary>
+        /// Tests that that <see cref="HealthController.GetHeartbeat"/> sends heartbeat messages.
+        /// </summary>
+        [TestMethod]
+        public void TestGetHearbeat()
+        {
+            ActionResult<HeartbeatMessage> heartbeatMessageActionResult = Controller.GetHeartbeat();
+            HeartbeatMessage heartbeatMessage = ExtractActionResultInnerResponseFromActionResult(heartbeatMessageActionResult, typeof(OkObjectResult));
+            Assert.IsNotNull(heartbeatMessage);
+            Assert.IsNotNull(heartbeatMessage.Message);
+            Assert.AreEqual(HeartbeatStatus.Ok, heartbeatMessage.Status);
+        }
+    }
+}

--- a/ChasmaWebApi.Tests/Controllers/RepositoryConfigurationControllerTests.cs
+++ b/ChasmaWebApi.Tests/Controllers/RepositoryConfigurationControllerTests.cs
@@ -1,0 +1,247 @@
+﻿using ChasmaWebApi.Controllers;
+using ChasmaWebApi.Data;
+using ChasmaWebApi.Data.Interfaces;
+using ChasmaWebApi.Data.Messages;
+using ChasmaWebApi.Data.Models;
+using ChasmaWebApi.Data.Objects;
+using ChasmaWebApi.Data.Requests;
+using ChasmaWebApi.Data.Responses;
+using ChasmaWebApi.Tests.Factories;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Concurrent;
+
+namespace ChasmaWebApi.Tests.Controllers
+{
+    /// <summary>
+    /// Class testing the functionality of the <see cref="RepositoryConfigurationController"/>.
+    /// </summary>
+    [TestClass]
+    public class RepositoryConfigurationControllerTests : ControllerTestBase<RepositoryConfigurationController>
+    {
+        /// <summary>
+        /// The mocked internal logger for API testing.
+        /// </summary>
+        private readonly Mock<ILogger<RepositoryConfigurationController>> loggerMock;
+
+        /// <summary>
+        /// The mocked repository configuration manager.
+        /// </summary>
+        private readonly Mock<IRepositoryConfigurationManager> configurationManagerMock;
+
+        /// <summary>
+        /// The mocked cached manager.
+        /// </summary>
+        private readonly Mock<ICacheManager> cacheManagerMock;
+
+        /// <summary>
+        /// The database context used for interacting with the database.
+        /// </summary>
+        private ApplicationDbContext applicationDbContext;
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RepositoryConfigurationControllerTests"/> class.
+        /// </summary>
+        public RepositoryConfigurationControllerTests()
+        {
+            loggerMock = new Mock<ILogger<RepositoryConfigurationController>>();
+            configurationManagerMock = new Mock<IRepositoryConfigurationManager>();
+            cacheManagerMock = new Mock<ICacheManager>();
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Set up the tests before each case is ran.
+        /// </summary>
+        [TestInitialize]
+        public void Setup()
+        {
+            CacheManagerFactory.SeedCacheManager(cacheManagerMock, TestRepositoryName, TestUserName);
+            Controller = new RepositoryConfigurationController(loggerMock.Object, configurationManagerMock.Object, cacheManagerMock.Object, applicationDbContext);
+        }
+
+        /// <summary>
+        /// Cleans up the resources after each test.
+        /// </summary>
+        [TestCleanup]
+        public void Cleanup()
+        {
+            configurationManagerMock.Reset();
+            cacheManagerMock.Reset();
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryConfigurationController.GetLocalGitRepositories"/> method gets the
+        /// local git repositories for a user.
+        /// Note: Arbitrary user 1 is being tested so it is expected to have two repos only: TestRepository and Chasma.
+        /// </summary>
+        [TestMethod]
+        public void TestGetLocalGitRepositories()
+        {
+            ActionResult<LocalRepositoriesInfoMessage> repoInfoMessageActionResult = Controller.GetLocalGitRepositories(1);
+            LocalRepositoriesInfoMessage message = ExtractActionResultInnerResponseFromActionResult(repoInfoMessageActionResult, typeof(OkObjectResult));
+            Assert.AreEqual(2, message.Repositories.Count);
+            List<string> repoNames = message.Repositories.Select(i => i.Name).ToList();
+            CollectionAssert.Contains(repoNames, TestRepositoryName);
+            CollectionAssert.Contains(repoNames, "Chasma");
+            CollectionAssert.DoesNotContain(repoNames, "KirbyGray");
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryConfigurationController.AddLocalGitRepositories(int)"/> sends an error response if no local repositories
+        /// cannot be found.
+        /// </summary>
+        [TestMethod]
+        public void TestAddLocalGitRepositoriesSendsErrorResponseWhenNoReposFound()
+        {
+            List<LocalGitRepository> newRepositories = new();
+            configurationManagerMock.Setup(x => x.TryAddLocalGitRepositories(It.IsAny<int>(), out newRepositories)).Returns(false);
+            Task<ActionResult<AddLocalRepositoriesResponse>> addLocalGitRepositoriesTask = Controller.AddLocalGitRepositories(1);
+            AddLocalRepositoriesResponse response = ExtractActionResultInnerResponseFromTask(addLocalGitRepositoriesTask, typeof(OkObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("No new local git repositories found on this machine.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryConfigurationController.AddLocalGitRepositories(int)"/> sends an successful in the nominal case.
+        /// </summary>
+        [TestMethod]
+        public void TestAddLocalGitRepositoriesNominalCase()
+        {
+            applicationDbContext = TestDbContextFactory.CreateApplicationDbContext();
+            TestDbContextFactory.SeedDatabase(applicationDbContext, TestUserFullName, TestUserName, TestUserPassword, TestUserEmail);
+            Controller = new RepositoryConfigurationController(loggerMock.Object, configurationManagerMock.Object, cacheManagerMock.Object, applicationDbContext);
+            List<LocalGitRepository> newRepositories = new()
+            {
+                CacheManagerFactory.CreateLocalGitRepository(1, TestRepositoryName, "chasma-bot"),
+                CacheManagerFactory.CreateLocalGitRepository(2, "Chasma", "chasma-bot"),
+            };
+            ConcurrentDictionary<string, string> workingDirectories = new();
+            foreach (LocalGitRepository repo in newRepositories)
+            {
+                workingDirectories.TryAdd(repo.Id, repo.Name);
+            }
+            cacheManagerMock.Setup(cacheManager => cacheManager.WorkingDirectories).Returns(workingDirectories);
+            configurationManagerMock.Setup(x => x.TryAddLocalGitRepositories(It.IsAny<int>(), out newRepositories)).Returns(true);
+            Task<ActionResult<AddLocalRepositoriesResponse>> addLocalGitRepositoriesTask = Controller.AddLocalGitRepositories(1);
+            AddLocalRepositoriesResponse response = ExtractActionResultInnerResponseFromTask(addLocalGitRepositoriesTask, typeof(OkObjectResult));
+            Assert.IsFalse(response.IsErrorResponse);
+            Assert.AreEqual(null, response.ErrorMessage);
+            Assert.AreEqual(2, response.CurrentRepositories.Count);
+            List<string> repoNames = response.CurrentRepositories.Select(r => r.Name).ToList();
+            CollectionAssert.Contains(repoNames, TestRepositoryName);
+            CollectionAssert.Contains(repoNames, "Chasma");
+            TestDbContextFactory.DestroyDatabase(applicationDbContext);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryConfigurationController.DeleteRepository(DeleteRepositoryRequest)"/> sends erorr response when null request is received.
+        /// </summary>
+        [TestMethod]
+        public void TestDeleteRepositoryFailedWithNullRequest()
+        {
+            Task<ActionResult<DeleteRepositoryResponse>> responseTask = Controller.DeleteRepository(null);
+            DeleteRepositoryResponse response = ExtractActionResultInnerResponseFromTask(responseTask, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Null request was received. Cannot delete repo.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryConfigurationController.DeleteRepository(DeleteRepositoryRequest)"/> sends erorr response when empty repository identifier is received.
+        /// </summary>
+        [TestMethod]
+        public void TestDeleteRepositoryFailedWithEmptyRepositoryId()
+        {
+            DeleteRepositoryRequest request = new()
+            {
+                RepositoryId = string.Empty,
+            };
+            Task<ActionResult<DeleteRepositoryResponse>> responseTask = Controller.DeleteRepository(request);
+            DeleteRepositoryResponse response = ExtractActionResultInnerResponseFromTask(responseTask, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Invalid request. Repository identifier is required.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryConfigurationController.DeleteRepository(DeleteRepositoryRequest)"/> sends erorr response when deletion error is reported.
+        /// </summary>
+        [TestMethod]
+        public void TestDeleteRepositoryWithDeletionFailure()
+        {
+            DeleteRepositoryRequest request = new()
+            {
+                RepositoryId = "testRepoId",
+            };
+
+            List<LocalGitRepository> repositories = new();
+            string errorMessage = "Error deleting repository.";
+            configurationManagerMock.Setup(manager => manager.TryDeleteRepository(It.IsAny<string>(), It.IsAny<int>(), out repositories, out errorMessage)).Returns(false);
+            Task<ActionResult<DeleteRepositoryResponse>> responseTask = Controller.DeleteRepository(request);
+            DeleteRepositoryResponse response = ExtractActionResultInnerResponseFromTask(responseTask, typeof(OkObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual(errorMessage, response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryConfigurationController.DeleteRepository(DeleteRepositoryRequest)"/> sends successful response on nominal case.
+        /// </summary>
+        [TestMethod]
+        public void TestDeleteRepositoryNominalCase()
+        {
+            LocalGitRepository testRepo = new LocalGitRepository
+            {
+                Id = Guid.NewGuid().ToString(),
+                UserId = 1,
+                Name = TestRepositoryName,
+                Owner = TestUserFullName,
+                Url = "url",
+            };
+
+            RepositoryModel repo = new()
+            {
+                Id = testRepo.Id,
+                Name = TestRepositoryName,
+                Owner = TestUserFullName,
+                Url = "url",
+                UserId = 1,
+            };
+
+            WorkingDirectoryModel workingDirectory = new()
+            {
+                RepositoryId = testRepo.Id,
+                WorkingDirectory = "path_xyz"
+            };
+            applicationDbContext = TestDbContextFactory.CreateApplicationDbContext();
+            TestDbContextFactory.SeedDatabase(applicationDbContext, TestUserFullName, TestUserName, TestUserPassword, TestUserEmail);
+            applicationDbContext.Repositories.Add(repo);
+            applicationDbContext.WorkingDirectories.Add(workingDirectory);
+            applicationDbContext.SaveChanges();
+
+            DeleteRepositoryRequest request = new()
+            {
+                RepositoryId = testRepo.Id,
+                UserId = 1
+            };
+
+            List<LocalGitRepository> repositories = new();
+            string errorMessage = string.Empty;
+            configurationManagerMock.Setup(manager => manager.TryDeleteRepository(It.IsAny<string>(), It.IsAny<int>(), out repositories, out errorMessage)).Returns(true);
+            
+            Controller = new RepositoryConfigurationController(loggerMock.Object, configurationManagerMock.Object, cacheManagerMock.Object, applicationDbContext);
+            Task<ActionResult<DeleteRepositoryResponse>> responseTask = Controller.DeleteRepository(request);
+            DeleteRepositoryResponse response = ExtractActionResultInnerResponseFromTask(responseTask, typeof(OkObjectResult));
+            Assert.IsFalse(response.IsErrorResponse);
+            Assert.AreEqual(null, response.ErrorMessage);
+
+            List<string> repoIds = cacheManagerMock.Object.Repositories.Values.Select(i => i.Id).ToList();
+            List<string> workingDirectoryKeys = cacheManagerMock.Object.Repositories.Keys.ToList();
+            CollectionAssert.DoesNotContain(repoIds, testRepo.Id);
+            CollectionAssert.DoesNotContain(workingDirectoryKeys, testRepo.Id);
+            TestDbContextFactory.DestroyDatabase(applicationDbContext);
+        }
+    }
+}

--- a/ChasmaWebApi.Tests/Controllers/RepositoryStatusControllerTests.cs
+++ b/ChasmaWebApi.Tests/Controllers/RepositoryStatusControllerTests.cs
@@ -1,0 +1,1440 @@
+﻿using ChasmaWebApi.Controllers;
+using ChasmaWebApi.Data;
+using ChasmaWebApi.Data.Interfaces;
+using ChasmaWebApi.Data.Models;
+using ChasmaWebApi.Data.Objects;
+using ChasmaWebApi.Data.Requests;
+using ChasmaWebApi.Data.Responses;
+using ChasmaWebApi.Util;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Concurrent;
+
+namespace ChasmaWebApi.Tests.Controllers
+{
+    /// <summary>
+    /// Class testing the functionality of the <see cref="RepositoryStatusController"/>.
+    /// </summary>
+    [TestClass]
+    public class RepositoryStatusControllerTests : ControllerTestBase<RepositoryStatusController>
+    {
+        /// <summary>
+        /// The API configurations options.
+        /// </summary>
+        private readonly ChasmaWebApiConfigurations webApiConfigurations;
+
+        /// <summary>
+        /// The database context used for interacting with the database.
+        /// </summary>
+        private readonly ApplicationDbContext applicationDbContext;
+
+        /// <summary>
+        /// The mocked internal API logger.
+        /// </summary>
+        private readonly Mock<ILogger<RepositoryStatusController>> loggerMock;
+
+        /// <summary>
+        /// The mocked internal repository status manager.
+        /// </summary>
+        private readonly Mock<IRepositoryStatusManager> statusManagerMock;
+
+        /// <summary>
+        /// The mocked internal cache manager.
+        /// </summary>
+        private readonly Mock<ICacheManager> cacheManagerMock;
+
+        /// <summary>
+        /// The configuration file location.
+        /// </summary>
+        private const string ConfigFilePath = "config.xml";
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RepositoryConfigurationControllerTests"/> class.
+        /// </summary>
+        public RepositoryStatusControllerTests()
+        {
+            statusManagerMock = new Mock<IRepositoryStatusManager>();
+            cacheManagerMock = new Mock<ICacheManager>();
+            loggerMock = new Mock<ILogger<RepositoryStatusController>>();
+            webApiConfigurations = ChasmaXmlBase.DeserializeFromFile<ChasmaWebApiConfigurations>(ConfigFilePath)!;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Sets up the resources before each unit test is ran.
+        /// </summary>
+        [TestInitialize]
+        public void Setup()
+        {
+            Controller = new RepositoryStatusController(loggerMock.Object, webApiConfigurations, statusManagerMock.Object, cacheManagerMock.Object, applicationDbContext);
+        }
+
+        /// <summary>
+        /// Cleans up the resources after each test is ran.
+        /// </summary>
+        [TestCleanup]
+        public void Cleanup()
+        {
+            loggerMock.Reset();
+            statusManagerMock.Reset();
+            cacheManagerMock.Reset();
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetChasmaWorkflowResults(GetWorkflowResultsRequest)"/> sends error response when
+        /// null request is received.
+        /// </summary>
+        [TestMethod]
+        public void TestGetChasmaWorkflowResultSendsErrorResponseWhenNullRequestIsReceived()
+        {
+            ActionResult<GitHubWorkflowRunResponse> actionResult = Controller.GetChasmaWorkflowResults(null);
+            GitHubWorkflowRunResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Null request received. Cannot get workflow runs.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetChasmaWorkflowResults(GetWorkflowResultsRequest)"/> sends error response when
+        /// empty repository name is received.
+        /// </summary>
+        [TestMethod]
+        public void TestGetChasmaWorkflowResultSendsErrorResponseWhenEmptyRepositoryNameIsReceived()
+        {
+            GetWorkflowResultsRequest request = new()
+            {
+                RepositoryName = string.Empty
+            };
+            ActionResult<GitHubWorkflowRunResponse> actionResult = Controller.GetChasmaWorkflowResults(request);
+            GitHubWorkflowRunResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Invalid request. Repository name is required.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetChasmaWorkflowResults(GetWorkflowResultsRequest)"/> sends error response when
+        /// empty repository owner is received.
+        /// </summary>
+        [TestMethod]
+        public void TestGetChasmaWorkflowResultSendsErrorResponseWhenEmptyRepositoryOwnerIsReceived()
+        {
+            GetWorkflowResultsRequest request = new()
+            {
+                RepositoryName = TestRepositoryName,
+                RepositoryOwner = string.Empty
+            };
+            ActionResult<GitHubWorkflowRunResponse> actionResult = Controller.GetChasmaWorkflowResults(request);
+            GitHubWorkflowRunResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Invalid request. Repository owner is required.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetChasmaWorkflowResults(GetWorkflowResultsRequest)"/> sends error response when
+        /// there is a failure getting run results.
+        /// </summary>
+        [TestMethod]
+        public void TestGetChasmaWorkflowResultSendsErrorResponseWhenFailureToGetRunResults()
+        {
+            GetWorkflowResultsRequest request = new()
+            {
+                RepositoryName = TestRepositoryName,
+                RepositoryOwner = TestUserName
+            };
+            string errorMessage = "Failed to get build results";
+            List<WorkflowRunResult> workflowRuns = new();
+            statusManagerMock.Setup(i => i.TryGetWorkflowRunResults(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), out workflowRuns, out errorMessage)).Returns(false);
+            ActionResult<GitHubWorkflowRunResponse> actionResult = Controller.GetChasmaWorkflowResults(request);
+            GitHubWorkflowRunResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual(errorMessage, response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetChasmaWorkflowResults(GetWorkflowResultsRequest)"/> sends error response when
+        /// there is a exception when attemtping to get run results.
+        /// </summary>
+        [TestMethod]
+        public void TestGetChasmaWorkflowResultSendsErrorResponseWhenExceptionOccurs()
+        {
+            GetWorkflowResultsRequest request = new()
+            {
+                RepositoryName = TestRepositoryName,
+                RepositoryOwner = TestUserName
+            };
+            string errorMessage = $"Error fetching workflow runs from {TestRepositoryName}. Check server logs for more information.";
+            List<WorkflowRunResult> workflowRuns = new();
+            statusManagerMock
+                .Setup(i => i.TryGetWorkflowRunResults(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), out workflowRuns, out errorMessage))
+                .Throws(new Exception("Exception getting run results."));
+            ActionResult<GitHubWorkflowRunResponse> actionResult = Controller.GetChasmaWorkflowResults(request);
+            GitHubWorkflowRunResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual(errorMessage, response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetChasmaWorkflowResults(GetWorkflowResultsRequest)"/> sends a successful response in the
+        /// nominal case.
+        /// </summary>
+        [TestMethod]
+        public void TestGetChasmaWorkflowResultsNominal()
+        {
+            GetWorkflowResultsRequest request = new()
+            {
+                RepositoryName = TestRepositoryName,
+                RepositoryOwner = TestUserName
+            };
+            WorkflowRunResult result = new()
+            {
+                AuthorName = TestUserFullName,
+                BranchName = "chasma",
+            };
+            string errorMessage = null;
+            List<WorkflowRunResult> workflowRuns = [result];
+            statusManagerMock
+                .Setup(i => i.TryGetWorkflowRunResults(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), out workflowRuns, out errorMessage))
+                .Returns(true);
+            ActionResult<GitHubWorkflowRunResponse> actionResult = Controller.GetChasmaWorkflowResults(request);
+            GitHubWorkflowRunResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsFalse(response.IsErrorResponse);
+            Assert.AreEqual(errorMessage, response.ErrorMessage);
+            Assert.AreEqual(TestRepositoryName, response.RepositoryName);
+            Assert.IsTrue(response.WorkflowRunResults.Count > 0);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetRepoStatus(GitStatusRequest)"/> sends error response when the request is null.
+        /// </summary>
+        [TestMethod]
+        public void TestGetRepoStatusSendsErrorResponseWithNullRequest()
+        {
+            ActionResult<GitStatusResponse> actionResult = Controller.GetRepoStatus(null);
+            GitStatusResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Request must be populated.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetRepoStatus(GitStatusRequest)"/> sends error response when the repository identifier is empty.
+        /// </summary>
+        [TestMethod]
+        public void TestGetRepoStatusWithEmptyRepositoryId()
+        {
+            GitStatusRequest request = new()
+            {
+                RepositoryId = string.Empty,
+            };
+            ActionResult<GitStatusResponse> actionResult = Controller.GetRepoStatus(request);
+            GitStatusResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("The repository identifier is null or empty.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetRepoStatus(GitStatusRequest)"/> sends error response when the repository
+        /// summary could not be retrieved.
+        /// </summary>
+        [TestMethod]
+        public void TestGetRepoStatusWithFailureToGetStatus()
+        {
+            GitStatusRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+            RepositorySummary summary = null;
+            statusManagerMock.Setup(i => i.GetRepositoryStatus(It.IsAny<string>())).Returns(summary);
+            ActionResult<GitStatusResponse> actionResult = Controller.GetRepoStatus(request);
+            GitStatusResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"Failed to get repository status for repo ID: {request.RepositoryId}", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetRepoStatus(GitStatusRequest)"/> sends success response when 
+        /// repository summary is retrieved.
+        /// </summary>
+        [TestMethod]
+        public void TestGetRepoStatusNominalCase()
+        {
+            GitStatusRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+            RepositorySummary summary = new()
+            {
+                CommitsAhead = 1,
+                CommitsBehind = 2,
+                CommitHash = "commit_hash",
+            };
+            statusManagerMock.Setup(i => i.GetRepositoryStatus(It.IsAny<string>())).Returns(summary);
+            ActionResult<GitStatusResponse> actionResult = Controller.GetRepoStatus(request);
+            GitStatusResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsFalse(response.IsErrorResponse);
+            Assert.AreEqual(null, response.ErrorMessage);
+            Assert.IsTrue(response.CommitsBehind > 0);
+            Assert.IsTrue(response.CommitsAhead > 0);
+            Assert.IsFalse(string.IsNullOrEmpty(response.CommitHash));
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.ApplyStagingAction(ApplyStagingActionRequest)"/> sends error response when the request is null.
+        /// </summary>
+        [TestMethod]
+        public void TestGetApplyStagingActionSendsErrorResponseWithNullRequest()
+        {
+            ActionResult<ApplyStagingActionResponse> actionResult = Controller.ApplyStagingAction(null);
+            ApplyStagingActionResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Request must be populated.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.ApplyStagingAction(ApplyStagingActionRequest)"/> sends error response when the repository key is empty.
+        /// </summary>
+        [TestMethod]
+        public void TestApplyStagingActionWithEmptyRepositoryKey()
+        {
+            ApplyStagingActionRequest request = new()
+            {
+                RepoKey = string.Empty,
+            };
+            ActionResult<ApplyStagingActionResponse> actionResult = Controller.ApplyStagingAction(request);
+            ApplyStagingActionResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Cannot process request because the repository key is not populated.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.ApplyStagingAction(ApplyStagingActionRequest)"/> sends error response when the file name is empty.
+        /// </summary>
+        [TestMethod]
+        public void TestApplyStagingActionWithEmptyFileName()
+        {
+            ApplyStagingActionRequest request = new()
+            {
+                RepoKey = Guid.NewGuid().ToString(),
+                FileName = string.Empty
+            };
+            ActionResult<ApplyStagingActionResponse> actionResult = Controller.ApplyStagingAction(request);
+            ApplyStagingActionResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Cannot process request because the file name is not populated.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.ApplyStagingAction(ApplyStagingActionRequest)"/> sends error response when the staging operation fails.
+        /// </summary>
+        [TestMethod]
+        public void TestApplyStagingActionFailsToApplyStagingAction()
+        {
+            ApplyStagingActionRequest request = new()
+            {
+                RepoKey = Guid.NewGuid().ToString(),
+                FileName = "path"
+            };
+            List<RepositoryStatusElement>? statusElements = null;
+            statusManagerMock.Setup(i => i.ApplyStagingAction(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>())).Returns(statusElements);
+            ActionResult<ApplyStagingActionResponse> actionResult = Controller.ApplyStagingAction(request);
+            ApplyStagingActionResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"Failed to apply staging action for repo ID: {request.RepoKey}. Check server logs for more information.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.ApplyStagingAction(ApplyStagingActionRequest)"/> sends success response when the staging operation succeeds.
+        /// </summary>
+        [TestMethod]
+        public void TestApplyStagingActionNominalCase()
+        {
+            ApplyStagingActionRequest request = new()
+            {
+                RepoKey = Guid.NewGuid().ToString(),
+                FileName = "path"
+            };
+            List<RepositoryStatusElement>? statusElements = [new(), new()];
+            statusManagerMock.Setup(i => i.ApplyStagingAction(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>())).Returns(statusElements);
+            ActionResult<ApplyStagingActionResponse> actionResult = Controller.ApplyStagingAction(request);
+            ApplyStagingActionResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsFalse(response.IsErrorResponse);
+            Assert.AreEqual(null, response.ErrorMessage);
+            Assert.IsTrue(response.StatusElements.Count > 0);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CommitChanges(GitCommitRequest)"/> sends error response when a null request is received.
+        /// </summary>
+        [TestMethod]
+        public void TestCommitChangesWithNullRequest()
+        {
+            ActionResult<GitCommitResponse> actionResult = Controller.CommitChanges(null);
+            GitCommitResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Null request received. Cannot commit changes.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CommitChanges(GitCommitRequest)"/> sends error response when empty repository identifier received.
+        /// </summary>
+        [TestMethod]
+        public void TestCommitChangesWithEmptyRepositoryId()
+        {
+            GitCommitRequest request = new()
+            {
+                RepositoryId = string.Empty
+            };
+            ActionResult<GitCommitResponse> actionResult = Controller.CommitChanges(request);
+            GitCommitResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Repository identifier must be populated. Cannot commit changes.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CommitChanges(GitCommitRequest)"/> sends error response when empty email received.
+        /// </summary>
+        [TestMethod]
+        public void TestCommitChangesWithEmptyEmail()
+        {
+            GitCommitRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                Email = string.Empty,
+            };
+            ActionResult<GitCommitResponse> actionResult = Controller.CommitChanges(request);
+            GitCommitResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Email must be populated for commit signature. Cannot commit changes.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CommitChanges(GitCommitRequest)"/> sends error response when empty commit message received.
+        /// </summary>
+        [TestMethod]
+        public void TestCommitChangesWithEmptyCommitMessage()
+        {
+            GitCommitRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                Email = "email",
+                CommitMessage = string.Empty
+            };
+            ActionResult<GitCommitResponse> actionResult = Controller.CommitChanges(request);
+            GitCommitResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Commit message cannot be empty. Cannot commit changes.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CommitChanges(GitCommitRequest)"/> sends error response when unknown repository identifier is received.
+        /// </summary>
+        [TestMethod]
+        public void TestCommitChangesWithUnknownRepositoryId()
+        {
+            GitCommitRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                Email = "email",
+                CommitMessage = "commit_message"
+            };
+            ConcurrentDictionary<string, string> workingDirectories = new();
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            ActionResult<GitCommitResponse> actionResult = Controller.CommitChanges(request);
+            GitCommitResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"No working directory found in cache for {request.RepositoryId}. Cannot commit changes.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CommitChanges(GitCommitRequest)"/> sends error response when unknown user identifier is received.
+        /// </summary>
+        [TestMethod]
+        public void TestCommitChangesWithUnknownUserId()
+        {
+            GitCommitRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                Email = "email",
+                CommitMessage = "commit_message",
+                UserId = 1,
+            };
+            ConcurrentDictionary<string, string> workingDirectories = new();
+            workingDirectories[request.RepositoryId] = "working_directory";
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+
+            ConcurrentDictionary<int, UserAccountModel> usersMapping = new();
+            cacheManagerMock.SetupGet(i => i.Users).Returns(usersMapping);
+
+            ActionResult<GitCommitResponse> actionResult = Controller.CommitChanges(request);
+            GitCommitResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"No user found in cache for user ID: {request.UserId}. Cannot commit changes.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CommitChanges(GitCommitRequest)"/> sends error response when commit changes operation
+        /// fails.
+        /// </summary>
+        [TestMethod]
+        public void TestCommitChangesWithCommitChangesFailure()
+        {
+            GitCommitRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                Email = "email",
+                CommitMessage = "commit_message",
+                UserId = 1,
+            };
+            ConcurrentDictionary<string, string> workingDirectories = new();
+            workingDirectories[request.RepositoryId] = "working_directory";
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+
+            UserAccountModel user = new()
+            {
+                Id = 1,
+                Email = "email",
+                Name = "name",
+                Password = "password",
+                Salt = [],
+                UserName = "username"
+            };
+            ConcurrentDictionary<int, UserAccountModel> usersMapping = new();
+            usersMapping[user.Id] = user;
+            cacheManagerMock.SetupGet(i => i.Users).Returns(usersMapping);
+
+            statusManagerMock
+                .Setup(i => i.CommitChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Throws(new Exception("Error occurred when committing changes."));
+
+            ActionResult<GitCommitResponse> actionResult = Controller.CommitChanges(request);
+            GitCommitResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"Error committing changes to repo: {request.RepositoryId}. Check server logs for more information.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CommitChanges(GitCommitRequest)"/> sends success response in the nominal case.
+        /// </summary>
+        [TestMethod]
+        public void TestCommitChangesNominalCase()
+        {
+            GitCommitRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                Email = "email",
+                CommitMessage = "commit_message",
+                UserId = 1,
+            };
+            ConcurrentDictionary<string, string> workingDirectories = new();
+            workingDirectories[request.RepositoryId] = "working_directory";
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+
+            UserAccountModel user = new()
+            {
+                Id = 1,
+                Email = "email",
+                Name = "name",
+                Password = "password",
+                Salt = [],
+                UserName = "username"
+            };
+            ConcurrentDictionary<int, UserAccountModel> usersMapping = new();
+            usersMapping[user.Id] = user;
+            cacheManagerMock.SetupGet(i => i.Users).Returns(usersMapping);
+
+            statusManagerMock.Setup(i => i.CommitChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
+
+            ActionResult<GitCommitResponse> actionResult = Controller.CommitChanges(request);
+            GitCommitResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsFalse(response.IsErrorResponse);
+            Assert.AreEqual(null, response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PushChanges(GitPushRequest)"/> sends error response when null request is received.
+        /// </summary>
+        [TestMethod]
+        public void TestPushChangesWithNullRequest()
+        {
+            ActionResult<GitPushResponse> actionResult = Controller.PushChanges(null);
+            GitPushResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Null request received. Cannot push changes.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PullChanges(GitPullRequest)"/> sends error response when empty repository identifier received.
+        /// </summary>
+        [TestMethod]
+        public void TestPushChangesWithEmptyRepositoryId()
+        {
+            GitPushRequest request = new()
+            {
+                RepositoryId = string.Empty
+            };
+            ActionResult<GitPushResponse> actionResult = Controller.PushChanges(request);
+            GitPushResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Repository identifier must be populated. Cannot push changes.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PushChanges(GitPushRequest)"/> sends error response when an unknown repository identifier is received.
+        /// </summary>
+        [TestMethod]
+        public void TestPushChangesWithUnknownRepositoryId()
+        {
+            GitPushRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+            ConcurrentDictionary<string, string> workingDirectories = new();
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            ActionResult<GitPushResponse> actionResult = Controller.PushChanges(request);
+            GitPushResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"No working directory found in cache for {request.RepositoryId}. Cannot push changes.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PushChanges(GitPushRequest)"/> sends error response when failure to push occurs.
+        /// </summary>
+        [TestMethod]
+        public void TestPushChangesWithFailureToPush()
+        {
+            GitPushRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+            ConcurrentDictionary<string, string> workingDirectories = new();
+            workingDirectories[request.RepositoryId] = "working_directory";
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+
+            string errorMessage = string.Empty;
+            statusManagerMock.Setup(i => i.TryPushChanges(It.IsAny<string>(), It.IsAny<string>(), out errorMessage)).Returns(false);
+
+            ActionResult<GitPushResponse> actionResult = Controller.PushChanges(request);
+            GitPushResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"Failed to push changes to repo: {request.RepositoryId}. {errorMessage}", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PushChanges(GitPushRequest)"/> sends success response in nominal case.
+        /// </summary>
+        [TestMethod]
+        public void TestPushChangesNominalCase()
+        {
+            GitPushRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+            ConcurrentDictionary<string, string> workingDirectories = new();
+            workingDirectories[request.RepositoryId] = "working_directory";
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+
+            string errorMessage = string.Empty;
+            statusManagerMock.Setup(i => i.TryPushChanges(It.IsAny<string>(), It.IsAny<string>(), out errorMessage)).Returns(true);
+
+            ActionResult<GitPushResponse> actionResult = Controller.PushChanges(request);
+            GitPushResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsFalse(response.IsErrorResponse);
+            Assert.AreEqual(null, response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PullChanges(GitPullRequest)"/> sends an error response when the request is null.
+        /// </summary>
+        [TestMethod]
+        public void TestPullChangesWithNullRequest()
+        {
+            ActionResult<GitPullResponse> actionResult = Controller.PullChanges(null);
+            GitPullResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Null request received. Cannot pull changes.", response.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PullChanges(GitPullRequest)"/> sends an error response when the request contains
+        /// empty repository identifier.
+        /// </summary>
+        [TestMethod]
+        public void TestPullChangesWithEmptyRepositoryId()
+        {
+            GitPullRequest request = new()
+            {
+                RepositoryId = string.Empty
+            };
+            ActionResult<GitPullResponse> actionResult  = Controller.PullChanges(request);
+            GitPullResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Repository identifier must be populated. Cannot pull changes.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PullChanges(GitPullRequest)"/> sends an error response when the request contains
+        /// empty email.
+        /// </summary>
+        [TestMethod]
+        public void TestPullChangesWithEmptyEmail()
+        {
+            GitPullRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                Email = string.Empty
+            };
+            ActionResult<GitPullResponse> actionResult  = Controller.PullChanges(request);
+            GitPullResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("User's email must be populated. Cannot pull changes.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PullChanges(GitPullRequest)"/> sends an error response when the request contains
+        /// unknown repository identifier.
+        /// </summary>
+        [TestMethod]
+        public void TestPullChangesWithUnknownRepositoryId()
+        {
+            GitPullRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                Email = "email",
+            };
+            ConcurrentDictionary<string, string> workingDirectories = new();
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            ActionResult<GitPullResponse> actionResult = Controller.PullChanges(request);
+            GitPullResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"No working directory found in cache for {request.RepositoryId}. Cannot pull changes.",  response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PullChanges(GitPullRequest)"/> sends an error response when the request contains
+        /// unknown user identifier.
+        /// </summary>
+        [TestMethod]
+        public void TestPullChangesWithUnknownUserId()
+        {
+            GitPullRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                Email = "email",
+                UserId = 1,
+            };
+            
+            ConcurrentDictionary<string, string> workingDirectories = new();
+            workingDirectories[request.RepositoryId] = "working_directory";
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            
+            ConcurrentDictionary<int, UserAccountModel> userAccounts = new();
+            cacheManagerMock.SetupGet(i => i.Users).Returns(userAccounts);
+            
+            ActionResult<GitPullResponse> actionResult = Controller.PullChanges(request);
+            GitPullResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"No user found in cache for user ID: {request.UserId}. Cannot pull changes.",  response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PullChanges(GitPullRequest)"/> sends an error response when repository fails to pull changes.
+        /// </summary>
+        [TestMethod]
+        public void TestPullChangesWithFailureToPullChangesForRepo()
+        {
+            GitPullRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                Email = "email",
+                UserId = 1,
+            };
+            
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            
+            ConcurrentDictionary<int, UserAccountModel> userAccounts = new();
+            userAccounts[request.UserId] = new UserAccountModel
+            {
+                Id = 1,
+                Email = "email",
+                Name = "name",
+                Password = "password",
+                Salt = [],
+                UserName = "username"
+            };
+            cacheManagerMock.SetupGet(i => i.Users).Returns(userAccounts);
+            
+            string errorMessage = string.Empty;
+            statusManagerMock
+                .Setup(i => i.TryPullChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), out errorMessage)) 
+                .Returns(false);
+            
+            ActionResult<GitPullResponse> actionResult = Controller.PullChanges(request);
+            GitPullResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"Failed to pull changes to repo: {request.RepositoryId}. {errorMessage}",  response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.PullChanges(GitPullRequest)"/> sends successful response for the nominal case.
+        /// </summary>
+        [TestMethod]
+        public void TestPullChangesNominalCase()
+        {
+            GitPullRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                Email = "email",
+                UserId = 1,
+            };
+            
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            
+            UserAccountModel user = new UserAccountModel
+            {
+                Id = 1,
+                Email = "email",
+                Name = "name",
+                Password = "password",
+                Salt = [],
+                UserName = "username"
+            };
+            ConcurrentDictionary<int, UserAccountModel> userAccounts = new()
+            {
+                [user.Id] = user
+            };
+            cacheManagerMock.SetupGet(i => i.Users).Returns(userAccounts);
+            
+            string errorMessage = string.Empty;
+            statusManagerMock
+                .Setup(i => i.TryPullChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), out errorMessage)) 
+                .Returns(true);
+            
+            ActionResult<GitPullResponse> actionResult = Controller.PullChanges(request);
+            GitPullResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsFalse(response.IsErrorResponse);
+            Assert.AreEqual(null, response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CheckoutBranch(GitCheckoutRequest)"/> sends error response when null request is received.
+        /// </summary>
+        [TestMethod]
+        public void TestCheckoutBranchWithNullRequest()
+        {
+            ActionResult<GitCheckoutResponse> actionResult = Controller.CheckoutBranch(null);
+            GitCheckoutResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Null request received. Cannot checkout branch.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CheckoutBranch(GitCheckoutRequest)"/> sends error response when empty repository identifier is received.
+        /// </summary>
+        [TestMethod]
+        public void TestCheckoutBranchWithEmptyRepositoryId()
+        {
+            GitCheckoutRequest request = new()
+            {
+                RepositoryId = string.Empty,
+            };
+            ActionResult<GitCheckoutResponse> actionResult = Controller.CheckoutBranch(request);
+            GitCheckoutResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Repository identifier must be populated. Cannot checkout branch.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CheckoutBranch(GitCheckoutRequest)"/> sends error response when an unknown repository identifier is received.
+        /// </summary>
+        [TestMethod]
+        public void TestCheckoutBranchWithUnknownRepositoryId()
+        {
+            GitCheckoutRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(new ConcurrentDictionary<string, string>());
+            ActionResult<GitCheckoutResponse> actionResult = Controller.CheckoutBranch(request);
+            GitCheckoutResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"No working directory found in cache for {request.RepositoryId}. Cannot checkout branch.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CheckoutBranch(GitCheckoutRequest)"/> sends error response when a failure to checkout branch occurs.
+        /// </summary>
+        [TestMethod]
+        public void TestCheckoutBranchWithCheckoutFailure()
+        {
+            GitCheckoutRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+            
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            
+            string errorMessage = "Failed to pull checkout branch";
+            statusManagerMock.Setup(i => i.TryCheckoutBranch(It.IsAny<string>(), It.IsAny<string>(), out errorMessage)).Returns(false);
+            ActionResult<GitCheckoutResponse> actionResult = Controller.CheckoutBranch(request);
+            GitCheckoutResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"Failed to checkout branch to repo: {request.RepositoryId}. {errorMessage}", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CheckoutBranch(GitCheckoutRequest)"/> sends error response when an unexpected exception occurs.
+        /// </summary>
+        [TestMethod]
+        public void TestCheckoutBranchWithUnexpectedException()
+        {
+            GitCheckoutRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+            
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            
+            string errorMessage = "Failed to pull checkout branch";
+            statusManagerMock.Setup(i => i.TryCheckoutBranch(It.IsAny<string>(), It.IsAny<string>(), out errorMessage)).Throws(new Exception("Exception checking out branch."));
+            ActionResult<GitCheckoutResponse> actionResult = Controller.CheckoutBranch(request);
+            GitCheckoutResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"Error checking out branch to repo: {request.RepositoryId}. Check server logs for more information.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CheckoutBranch(GitCheckoutRequest)"/> sends successful response in nominal case.
+        /// </summary>
+        [TestMethod]
+        public void TestCheckoutBranchNominalCase()
+        {
+            GitCheckoutRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+            
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            
+            string errorMessage = null;
+            statusManagerMock.Setup(i => i.TryCheckoutBranch(It.IsAny<string>(), It.IsAny<string>(), out errorMessage)).Returns(true);
+            ActionResult<GitCheckoutResponse> actionResult = Controller.CheckoutBranch(request);
+            GitCheckoutResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsFalse(response.IsErrorResponse);
+            Assert.AreEqual(errorMessage, response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetBranches(GitBranchRequest)"/> sends error response when null request is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestGetBranchesWithNullRequest()
+        {
+            ActionResult<GitBranchResponse> actionResult = Controller.GetBranches(null);
+            GitBranchResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Null request received. Cannot get branches.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetBranches(GitBranchRequest)"/> sends error response when empty repository identifier is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestGetBranchesWithEmptyRepositoryId()
+        {
+            GitBranchRequest request = new()
+            {
+                RepositoryId = string.Empty,
+            };
+            ActionResult<GitBranchResponse> actionResult = Controller.GetBranches(request);
+            GitBranchResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Repository identifier must be populated. Cannot get branches.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetBranches(GitBranchRequest)"/> sends error response when unknown repository identifier is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestGetBranchesWithUnknownRepositoryId()
+        {
+            GitBranchRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(new ConcurrentDictionary<string, string>());
+            ActionResult<GitBranchResponse> actionResult = Controller.GetBranches(request);
+            GitBranchResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"No working directory found in cache for {request.RepositoryId}. Cannot get branches.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetBranches(GitBranchRequest)"/> sends error response when there is failure to get branches via git operations. 
+        /// </summary>
+        [TestMethod]
+        public void TestGetBranchesWithFailureToGetBranches()
+        {
+            GitBranchRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            statusManagerMock.Setup(i => i.GetAllBranches(It.IsAny<string>())).Throws(new Exception("Exception getting branches."));
+            ActionResult<GitBranchResponse> actionResult = Controller.GetBranches(request);
+            GitBranchResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"Error getting branches for repo: {request.RepositoryId}. Check server logs for more information.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.GetBranches(GitBranchRequest)"/> sends successful response in the nominal case. 
+        /// </summary>
+        [TestMethod]
+        public void TestGetBranchesNominalCase()
+        {
+            GitBranchRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+
+            List<string> branchNames = ["chasma", "unit", "test"];
+            statusManagerMock.Setup(i => i.GetAllBranches(It.IsAny<string>())).Returns(branchNames);
+            ActionResult<GitBranchResponse> actionResult = Controller.GetBranches(request);
+            GitBranchResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsFalse(response.IsErrorResponse);
+            Assert.AreEqual(null, response.ErrorMessage);
+            Assert.IsTrue(response.BranchNames.Count == branchNames.Count);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends error response when null request is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestWithNullRequest()
+        {
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(null);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Null request received. Cannot create pull request.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends error response when empty repository identifier is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestWithEmptyRepositoryId()
+        {
+            CreatePRRequest request = new()
+            {
+                RepositoryId = string.Empty,
+            };
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(request);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Repository identifier must be populated. Cannot get branches.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends error response when an unknown repository identifier is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestWithUnknownRepositoryId()
+        {
+            CreatePRRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(new ConcurrentDictionary<string, string>());
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(request);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"No working directory found in cache for {request.RepositoryId}. Cannot get branches.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends error response when an empty pull request title is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestWithEmptyPullRequestTitle()
+        {
+            CreatePRRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                PullRequestTitle = string.Empty,
+            };
+
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(request);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Pull request title must be populated. Cannot create pull request.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends error response when an empty working branch name is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestWithEmptyWorkingBranchName()
+        {
+            CreatePRRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                PullRequestTitle = "title",
+                WorkingBranchName = string.Empty,
+            };
+
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(request);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Working branch name must be populated. Cannot create pull request.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends error response when an empty destination branch name is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestWithEmptyDestinationBranchName()
+        {
+            CreatePRRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                PullRequestTitle = "title",
+                WorkingBranchName = "working_branch",
+                DestinationBranchName = string.Empty,
+            };
+
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(request);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Destination branch name must be populated. Cannot create pull request.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends error response when an empty pull request body is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestWithEmptyPullRequestBody()
+        {
+            CreatePRRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                PullRequestTitle = "title",
+                WorkingBranchName = "working_branch",
+                DestinationBranchName = "destination_branch",
+                PullRequestBody = string.Empty,
+            };
+
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(request);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Pull request body message must be populated. Cannot create pull request.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends error response when an empty repository owner is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestWithEmptyRepositoryOwner()
+        {
+            CreatePRRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                PullRequestTitle = "title",
+                WorkingBranchName = "working_branch",
+                DestinationBranchName = "destination_branch",
+                PullRequestBody = "pull_request_body",
+            };
+
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+            cacheManagerMock.SetupGet(i => i.Repositories).Returns(new ConcurrentDictionary<string, LocalGitRepository>());
+            
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(request);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Owner of repository not found. Cannot create pull request.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends error response when an empty repository name is received. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestWithEmptyRepositoryName()
+        {
+            CreatePRRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                PullRequestTitle = "title",
+                WorkingBranchName = "working_branch",
+                DestinationBranchName = "destination_branch",
+                PullRequestBody = "pull_request_body",
+                RepositoryName = string.Empty,
+            };
+
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+
+            LocalGitRepository repository = new()
+            {
+                UserId = 1,
+                Id = request.RepositoryId,
+                Owner = "chasma"
+            };
+            ConcurrentDictionary<string, LocalGitRepository> repositories = new()
+            {
+                [request.RepositoryId] = repository
+            };
+            cacheManagerMock.SetupGet(i => i.Repositories).Returns(repositories);
+            
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(request);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(BadRequestObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual("Repository name must be populated. Cannot create pull request.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends error response when a failure to create a pull request occurs. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestWithFailureToCreatePullRequest()
+        {
+            CreatePRRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                PullRequestTitle = "title",
+                WorkingBranchName = "working_branch",
+                DestinationBranchName = "destination_branch",
+                PullRequestBody = "pull_request_body",
+                RepositoryName = TestRepositoryName,
+            };
+
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+
+            LocalGitRepository repository = new()
+            {
+                UserId = 1,
+                Id = request.RepositoryId,
+                Owner = "chasma"
+            };
+            ConcurrentDictionary<string, LocalGitRepository> repositories = new()
+            {
+                [request.RepositoryId] = repository
+            };
+            cacheManagerMock.SetupGet(i => i.Repositories).Returns(repositories);
+            
+            int pullRequestId = 0;
+            string prUrl = string.Empty;
+            string timestamp = string.Empty;
+            string errorMessage = string.Empty;
+
+            statusManagerMock.Setup(i => i.TryCreatePullRequest(
+                It.IsAny<string>(),
+                        It.IsAny<string>(),
+                     It.IsAny<string>(),
+                          It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                         It.IsAny<string>(),
+                         It.IsAny<string>(),
+                              out pullRequestId,
+                              out prUrl,
+                              out timestamp,
+                              out errorMessage)
+                ).Returns(false);
+            
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(request);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"Failed to create pull request for repo: {request.RepositoryName}. {errorMessage}", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends error response when an exception occurs. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestWithUnexpectedException()
+        {
+            CreatePRRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                PullRequestTitle = "title",
+                WorkingBranchName = "working_branch",
+                DestinationBranchName = "destination_branch",
+                PullRequestBody = "pull_request_body",
+                RepositoryName = TestRepositoryName,
+            };
+
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+
+            LocalGitRepository repository = new()
+            {
+                UserId = 1,
+                Id = request.RepositoryId,
+                Owner = "chasma"
+            };
+            ConcurrentDictionary<string, LocalGitRepository> repositories = new()
+            {
+                [request.RepositoryId] = repository
+            };
+            cacheManagerMock.SetupGet(i => i.Repositories).Returns(repositories);
+            
+            int pullRequestId = 0;
+            string prUrl = string.Empty;
+            string timestamp = string.Empty;
+            string errorMessage = string.Empty;
+
+            statusManagerMock.Setup(i => i.TryCreatePullRequest(
+                It.IsAny<string>(),
+                        It.IsAny<string>(),
+                     It.IsAny<string>(),
+                          It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                         It.IsAny<string>(),
+                         It.IsAny<string>(),
+                              out pullRequestId,
+                              out prUrl,
+                              out timestamp,
+                              out errorMessage)
+                ).Throws(new Exception("Exception generating pull request."));
+            
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(request);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsTrue(response.IsErrorResponse);
+            Assert.AreEqual($"Error creating pull request for repo: {request.RepositoryName}. Check server logs for more information.", response.ErrorMessage);
+        }
+        
+        /// <summary>
+        /// Tests that the <see cref="RepositoryStatusController.CreatePullRequest(CreatePRRequest)"/> sends successful response in the nominal case. 
+        /// </summary>
+        [TestMethod]
+        public void TestCreatePullRequestNominalCase()
+        {
+            CreatePRRequest request = new()
+            {
+                RepositoryId = Guid.NewGuid().ToString(),
+                PullRequestTitle = "title",
+                WorkingBranchName = "working_branch",
+                DestinationBranchName = "destination_branch",
+                PullRequestBody = "pull_request_body",
+                RepositoryName = TestRepositoryName,
+            };
+
+            ConcurrentDictionary<string, string> workingDirectories = new()
+            {
+                [request.RepositoryId] = "working_directory"
+            };
+            cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+
+            LocalGitRepository repository = new()
+            {
+                UserId = 1,
+                Id = request.RepositoryId,
+                Owner = "chasma"
+            };
+            ConcurrentDictionary<string, LocalGitRepository> repositories = new()
+            {
+                [request.RepositoryId] = repository
+            };
+            cacheManagerMock.SetupGet(i => i.Repositories).Returns(repositories);
+            
+            int pullRequestId = 0;
+            string prUrl = "url.com";
+            string timestamp = "1-01-2026";
+            string errorMessage = null;
+
+            statusManagerMock.Setup(i => i.TryCreatePullRequest(
+                It.IsAny<string>(),
+                        It.IsAny<string>(),
+                     It.IsAny<string>(),
+                          It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                         It.IsAny<string>(),
+                         It.IsAny<string>(),
+                              out pullRequestId,
+                              out prUrl,
+                              out timestamp,
+                              out errorMessage)
+                ).Returns(true);
+            
+            ActionResult<CreatePRResponse> actionResult = Controller.CreatePullRequest(request);
+            CreatePRResponse response = ExtractActionResultInnerResponseFromActionResult(actionResult, typeof(OkObjectResult));
+            Assert.IsFalse(response.IsErrorResponse);
+            Assert.AreEqual(errorMessage, response.ErrorMessage);
+            Assert.AreEqual(pullRequestId, response.PullRequestId);
+            Assert.AreEqual(prUrl, response.PullRequestUrl);
+            Assert.AreEqual(timestamp, response.TimeStamp);
+        }
+    }
+}

--- a/ChasmaWebApi.Tests/Controllers/UserControllerTests.cs
+++ b/ChasmaWebApi.Tests/Controllers/UserControllerTests.cs
@@ -1,0 +1,319 @@
+﻿using ChasmaWebApi.Controllers;
+using ChasmaWebApi.Data;
+using ChasmaWebApi.Data.Interfaces;
+using ChasmaWebApi.Data.Requests;
+using ChasmaWebApi.Data.Responses;
+using ChasmaWebApi.Tests.Factories;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace ChasmaWebApi.Tests.Controllers
+{
+    /// <summary>
+    /// Class testing the functionality of the <see cref="UserController"/> class.
+    /// </summary>
+    [TestClass]
+    public class UserControllerTests : ControllerTestBase<UserController>
+    {
+        /// <summary>
+        /// The database context used for testing.
+        /// </summary>
+        private ApplicationDbContext dbContext;
+
+        /// <summary>
+        /// The mocked internal logger for API testing.
+        /// </summary>
+        private readonly Mock<ILogger<UserController>> loggerMock;
+
+        /// <summary>
+        /// The mocked password utility for API testing.
+        /// </summary>
+        private readonly Mock<IPasswordUtility> passwordUtilityMock;
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserControllerTests"/> class.
+        /// </summary>
+        public UserControllerTests()
+        {
+            loggerMock = new Mock<ILogger<UserController>>();
+            passwordUtilityMock = new Mock<IPasswordUtility>();
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Sets up resources before each test.
+        /// </summary>
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            Controller = new UserController(dbContext, loggerMock.Object, passwordUtilityMock.Object);
+        }
+
+        /// <summary>
+        /// Disposes of test resources after each test.
+        /// </summary>
+        [TestCleanup]
+        public void CleanupTests()
+        {
+            passwordUtilityMock.Reset();
+            loggerMock.Reset();
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.Login(LoginRequest)"/> sends a login error response is sent when the request is null.
+        /// Note: It is expected that none of the values retrieved will be null and warnings can be safely ignored.
+        /// </summary>
+        [TestMethod]
+        public void TestLoginFailsWithNullLoginRequest()
+        {
+            Task<ActionResult<LoginResponse>> responseTask = Controller.Login(null);
+            LoginResponse loginResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(BadRequestObjectResult));
+            Assert.IsTrue(loginResponse.IsErrorResponse);
+            Assert.AreEqual("Request was null. Cannot login user.", loginResponse.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.Login(LoginRequest)"/> sends a login error response is sent when the request has an empty username field.
+        /// Note: It is expected that none of the values retrieved will be null and warnings can be safely ignored.
+        /// </summary>
+        [TestMethod]
+        public void TestLoginFailsWithEmptyUsername()
+        {
+            LoginRequest request = new LoginRequest
+            {
+                UserName = string.Empty,
+            };
+            Task<ActionResult<LoginResponse>> responseTask = Controller.Login(request);
+            LoginResponse loginResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(BadRequestObjectResult));
+            Assert.IsTrue(loginResponse.IsErrorResponse);
+            Assert.AreEqual("Username is empty. Cannot login user.", loginResponse.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.Login(LoginRequest)"/> sends a login error response is sent when the request has an empty password field.
+        /// Note: It is expected that none of the values retrieved will be null and warnings can be safely ignored.
+        /// </summary>
+        [TestMethod]
+        public void TestLoginFailsWithEmptyPassword()
+        {
+            LoginRequest request = new LoginRequest
+            {
+                UserName = "user1",
+                Password = string.Empty
+            };
+            Task<ActionResult<LoginResponse>> responseTask = Controller.Login(request);
+            LoginResponse loginResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(BadRequestObjectResult));
+            Assert.IsTrue(loginResponse.IsErrorResponse);
+            Assert.AreEqual("Password is empty. Cannot login user.", loginResponse.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.Login(LoginRequest)"/> sends a login error response is sent when the request has a username that does not exist.
+        /// Note: It is expected that none of the values retrieved will be null and warnings can be safely ignored.
+        /// </summary>
+        [TestMethod]
+        public void TestLoginFailsWithUnknownUser()
+        {
+            dbContext = TestDbContextFactory.CreateApplicationDbContext();
+            TestDbContextFactory.SeedDatabase(dbContext, TestUserFullName, TestUserName, TestUserPassword, TestUserEmail);
+            Controller = new UserController(dbContext, loggerMock.Object, passwordUtilityMock.Object);
+            LoginRequest request = new LoginRequest
+            {
+                UserName = "user1",
+                Password = "password1"
+            };
+            Task<ActionResult<LoginResponse>> responseTask = Controller.Login(request);
+            LoginResponse loginResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(BadRequestObjectResult));
+            Assert.IsTrue(loginResponse.IsErrorResponse);
+            Assert.AreEqual("User not found.", loginResponse.ErrorMessage);
+            TestDbContextFactory.DestroyDatabase(dbContext);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.Login(LoginRequest)"/> sends a login error response is sent when the request has a username that is found but the password is incorrect.
+        /// Note: It is expected that none of the values retrieved will be null and warnings can be safely ignored.
+        /// </summary>
+        [TestMethod]
+        public void TestLoginFailsWithIncorrectPassword()
+        {
+            dbContext = TestDbContextFactory.CreateApplicationDbContext();
+            TestDbContextFactory.SeedDatabase(dbContext, TestUserFullName, TestUserName, TestUserPassword, TestUserEmail);
+            Controller = new UserController(dbContext, loggerMock.Object, passwordUtilityMock.Object);
+            LoginRequest request = new LoginRequest
+            {
+                UserName = TestUserName,
+                Password = "password1"
+            };
+            Task<ActionResult<LoginResponse>> responseTask = Controller.Login(request);
+            LoginResponse loginResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(OkObjectResult));
+            Assert.IsTrue(loginResponse.IsErrorResponse);
+            Assert.AreEqual("Invalid password.", loginResponse.ErrorMessage);
+            TestDbContextFactory.DestroyDatabase(dbContext);
+        }
+
+        /// <summary>
+        /// Tests the nominal case of the <see cref="UserController.Login(LoginRequest)"/> sends a successful response.
+        /// Note: It is expected that none of the values retrieved will be null and warnings can be safely ignored.
+        /// </summary>
+        [TestMethod]
+        public void TestSuccessfulLogin()
+        {
+            dbContext = TestDbContextFactory.CreateApplicationDbContext();
+            TestDbContextFactory.SeedDatabase(dbContext, TestUserFullName, TestUserName, TestUserPassword, TestUserEmail);
+            Controller = new UserController(dbContext, loggerMock.Object, passwordUtilityMock.Object);
+            passwordUtilityMock.Setup(utility => utility.VerifyPassword(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string>())).Returns(true);
+            LoginRequest request = new LoginRequest
+            {
+                UserName = TestUserName,
+                Password = TestUserPassword,
+            };
+            Task<ActionResult<LoginResponse>> responseTask = Controller.Login(request);
+            LoginResponse loginResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(OkObjectResult));
+            Assert.IsFalse(loginResponse.IsErrorResponse);
+            Assert.AreEqual(null, loginResponse.ErrorMessage);
+            Assert.AreEqual(TestUserName, loginResponse.UserName);
+            Assert.AreEqual(TestUserEmail, loginResponse.Email);
+            Assert.IsTrue(loginResponse.UserId > 0);
+            TestDbContextFactory.DestroyDatabase(dbContext);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.AddUserAccount(AddUserRequest)"/> sends a login error response is sent when the request is null.
+        /// </summary>
+        [TestMethod]
+        public void TestAddUserFailsWithNullAddUserRequest()
+        {
+            Task<ActionResult<AddUserResponse>> responseTask = Controller.AddUserAccount(null);
+            AddUserResponse addUserResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(BadRequestObjectResult));
+            Assert.IsTrue(addUserResponse.IsErrorResponse);
+            Assert.AreEqual("Request was null. Cannot add user.", addUserResponse.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.AddUserAccount(AddUserRequest)"/> sends a login error response is sent when the full name is empty.
+        /// </summary>
+        [TestMethod]
+        public void TestAddUserFailsWithEmptyUserFullName()
+        {
+            AddUserRequest request = new AddUserRequest
+            {
+                Name = string.Empty,
+            };
+            Task <ActionResult<AddUserResponse>> responseTask = Controller.AddUserAccount(request);
+            AddUserResponse addUserResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(BadRequestObjectResult));
+            Assert.IsTrue(addUserResponse.IsErrorResponse);
+            Assert.AreEqual("Name is empty. Cannot add user.", addUserResponse.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.AddUserAccount(AddUserRequest)"/> sends a login error response is sent when the username is empty.
+        /// </summary>
+        [TestMethod]
+        public void TestAddUserFailsWithEmptyUserName()
+        {
+            AddUserRequest request = new AddUserRequest
+            {
+                Name = "user",
+                UserName = string.Empty,
+            };
+            Task<ActionResult<AddUserResponse>> responseTask = Controller.AddUserAccount(request);
+            AddUserResponse addUserResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(BadRequestObjectResult));
+            Assert.IsTrue(addUserResponse.IsErrorResponse);
+            Assert.AreEqual("Username is empty. Cannot add user.", addUserResponse.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.AddUserAccount(AddUserRequest)"/> sends a login error response is sent when the password is empty.
+        /// </summary>
+        [TestMethod]
+        public void TestAddUserFailsWithEmptyPassword()
+        {
+            AddUserRequest request = new AddUserRequest
+            {
+                Name = "name",
+                UserName = "username",
+                Password = string.Empty
+            };
+            Task<ActionResult<AddUserResponse>> responseTask = Controller.AddUserAccount(request);
+            AddUserResponse addUserResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(BadRequestObjectResult));
+            Assert.IsTrue(addUserResponse.IsErrorResponse);
+            Assert.AreEqual("Password is empty. Cannot add user.", addUserResponse.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.AddUserAccount(AddUserRequest)"/> sends a login error response is sent when the user already exists.
+        /// </summary>
+        [TestMethod]
+        public void TestAddUserFailsWithExistingUser()
+        {
+            dbContext = TestDbContextFactory.CreateApplicationDbContext();
+            TestDbContextFactory.SeedDatabase(dbContext, TestUserFullName, TestUserName, TestUserPassword, TestUserEmail);
+            Controller = new UserController(dbContext, loggerMock.Object, passwordUtilityMock.Object);
+            AddUserRequest request = new AddUserRequest
+            {
+                Name = TestUserFullName,
+                UserName = TestUserName,
+                Password = TestUserPassword,
+            };
+            Task<ActionResult<AddUserResponse>> responseTask = Controller.AddUserAccount(request);
+            AddUserResponse addUserResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(OkObjectResult));
+            Assert.IsTrue(addUserResponse.IsErrorResponse);
+            Assert.AreEqual("Username already exists. Cannot add user.", addUserResponse.ErrorMessage);
+            TestDbContextFactory.DestroyDatabase(dbContext);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.AddUserAccount(AddUserRequest)"/> sends a login error response is sent when the database fails to add user.
+        /// </summary>
+        [TestMethod]
+        public void TestAddUserFailsWithInvalidValues()
+        {
+            dbContext = TestDbContextFactory.CreateApplicationDbContext();
+            TestDbContextFactory.SeedDatabase(dbContext, TestUserFullName, TestUserName, TestUserPassword, TestUserEmail);
+            Controller = new UserController(dbContext, loggerMock.Object, passwordUtilityMock.Object);
+            passwordUtilityMock.Setup(utility => utility.HashPassword(It.IsAny<string>())).Returns((null, null));
+            AddUserRequest request = new AddUserRequest
+            {
+                Name = "name",
+                UserName = "username",
+                Password = "password"
+            };
+            Task<ActionResult<AddUserResponse>> responseTask = Controller.AddUserAccount(request);
+            AddUserResponse addUserResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(OkObjectResult));
+            Assert.IsTrue(addUserResponse.IsErrorResponse);
+            Assert.AreEqual("User could not be added to the system. Check server logs for more information.", addUserResponse.ErrorMessage);
+            TestDbContextFactory.DestroyDatabase(dbContext);
+        }
+
+        /// <summary>
+        /// Tests that the <see cref="UserController.AddUserAccount(AddUserRequest)"/> sends successful response when all request parameters are valid.
+        /// </summary>
+        [TestMethod]
+        public void TestAddUserFailsNominal()
+        {
+            dbContext = TestDbContextFactory.CreateApplicationDbContext();
+            TestDbContextFactory.SeedDatabase(dbContext, TestUserFullName, TestUserName, TestUserPassword, TestUserEmail);
+            Controller = new UserController(dbContext, loggerMock.Object, passwordUtilityMock.Object);
+            AddUserRequest request = new AddUserRequest
+            {
+                Name = "name",
+                UserName = "username",
+                Password = "password",
+                Email = "email"
+            };
+            passwordUtilityMock.Setup(utility => utility.HashPassword(It.IsAny<string>())).Returns((request.Password, [1, 2, 3]));
+            Task<ActionResult<AddUserResponse>> responseTask = Controller.AddUserAccount(request);
+            AddUserResponse addUserResponse = ExtractActionResultInnerResponseFromTask(responseTask, typeof(OkObjectResult));
+            Assert.IsFalse(addUserResponse.IsErrorResponse);
+            Assert.AreEqual(null, addUserResponse.ErrorMessage);
+            Assert.AreEqual(request.UserName, addUserResponse.UserName);
+            Assert.IsNotNull(addUserResponse.Email);
+            Assert.IsTrue(addUserResponse.UserId > 0);
+            TestDbContextFactory.DestroyDatabase(dbContext);
+        }
+    }
+}

--- a/ChasmaWebApi.Tests/Factories/CacheManagerFactory.cs
+++ b/ChasmaWebApi.Tests/Factories/CacheManagerFactory.cs
@@ -1,0 +1,57 @@
+﻿using ChasmaWebApi.Data.Interfaces;
+using ChasmaWebApi.Data.Objects;
+using Moq;
+using System.Collections.Concurrent;
+
+namespace ChasmaWebApi.Tests.Factories
+{
+    /// <summary>
+    /// Utility class for creating test cache object instances.
+    /// </summary>
+    public static class CacheManagerFactory
+    {
+        /// <summary>
+        /// Seeds the cache manager with test data.
+        /// </summary>
+        /// <param name="cacheManagerMock">The mocked cache manager.</param>
+        /// <param name="repoName">The name of the repository.</param>
+        /// <param name="username">The username of the system.</param>
+        public static void SeedCacheManager(Mock<ICacheManager> cacheManagerMock, string repoName, string username)
+        {
+            LocalGitRepository repo1 = CreateLocalGitRepository(1, repoName, username);
+            LocalGitRepository repo2 = CreateLocalGitRepository(1, "Chasma", "batman");
+            LocalGitRepository repo3 = CreateLocalGitRepository(123, "KirbyGray", "batman");
+            ConcurrentDictionary<string, LocalGitRepository> repositories = new();
+            repositories[repo1.Id] = repo1;
+            repositories[repo2.Id] = repo2;
+            repositories[repo3.Id] = repo3;
+
+            ConcurrentDictionary<string, string> workingDirectories = new();
+            workingDirectories[repo1.Id] = "path1";
+            workingDirectories[repo2.Id] = "path2";
+            workingDirectories[repo3.Id] = "path2";
+
+            cacheManagerMock.SetupGet(mock => mock.Repositories).Returns(repositories);
+            cacheManagerMock.SetupGet(mock => mock.WorkingDirectories).Returns(workingDirectories);
+        }
+
+        /// <summary>
+        /// Creates a sample local git repository object.
+        /// </summary>
+        /// <param name="userId">The user identifier.</param>
+        /// <param name="repoName">The repository name.</param>
+        /// <param name="owner">The repository owner.</param>
+        /// <returns>A sample local git repository instance.</returns>
+        public static LocalGitRepository CreateLocalGitRepository(int userId, string repoName, string owner)
+        {
+            return new LocalGitRepository
+            {
+                Id = Guid.NewGuid().ToString(),
+                UserId = userId,
+                Name = repoName,
+                Owner = owner,
+                Url = "url",
+            };
+        }
+    }
+}

--- a/ChasmaWebApi.Tests/Factories/TestDbContextFactory.cs
+++ b/ChasmaWebApi.Tests/Factories/TestDbContextFactory.cs
@@ -1,0 +1,56 @@
+﻿using ChasmaWebApi.Data;
+using ChasmaWebApi.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ChasmaWebApi.Tests.Factories
+{
+    /// <summary>
+    /// Utility class for creating test database context instances.
+    /// </summary>
+    public static class TestDbContextFactory
+    {
+        /// <summary>
+        /// Creates a new application database context for testing.
+        /// </summary>
+        /// <returns>The test instance of the application database context.</returns>
+        public static ApplicationDbContext CreateApplicationDbContext()
+        {
+            string guid = Guid.NewGuid().ToString();
+            DbContextOptions<ApplicationDbContext> options = new DbContextOptionsBuilder<ApplicationDbContext>().UseInMemoryDatabase(guid).Options;
+            ApplicationDbContext context = new ApplicationDbContext(options);
+            return context;
+        }
+
+        /// <summary>
+        /// Seeds the database with initial data for testing.
+        /// </summary>
+        /// <param name="context">The application database context.</param>
+        /// <param name="fullName">The full name of the user.</param>
+        /// <param name="username">The username of the user.</param>
+        /// <param name="password">The password of the user.</param>
+        /// <param name="email">The email of the user.</param>
+        public static void SeedDatabase(ApplicationDbContext context, string fullName, string username, string password, string email)
+        {
+            UserAccountModel testUser = new()
+            {
+                Name = fullName,
+                UserName = username,
+                Password = password,
+                Email = email,
+                Salt = [],
+            };
+            context.UserAccounts.Add(testUser);
+            context.SaveChanges();
+        }
+
+        /// <summary>
+        /// Destroys the test database and disposes of the context.
+        /// </summary>
+        /// <param name="context">The application database context.</param>
+        public static void DestroyDatabase(ApplicationDbContext context)
+        {
+            context.Database.EnsureDeleted();
+            context.Dispose();
+        }
+    }
+}

--- a/ChasmaWebApi.Tests/Util/XmlSerializationTests.cs
+++ b/ChasmaWebApi.Tests/Util/XmlSerializationTests.cs
@@ -1,7 +1,7 @@
 ﻿using ChasmaWebApi.Data.Objects;
 using ChasmaWebApi.Util;
 
-namespace ChasmaWebApi.Tests
+namespace ChasmaWebApi.Tests.Util
 {
     /// <summary>
     /// Class testing the functionality of the <see cref="ChasmaXmlBase"/> class.

--- a/ChasmaWebApi.Tests/config.xml
+++ b/ChasmaWebApi.Tests/config.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configurations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <webApiUrl>https://localhost:44349/</webApiUrl>
-  <databaseConfiguration>
-    <server>localhost\SQLEXPRESS</server>
-    <databaseName>Chasma</databaseName>
-    <trustedConnection>true</trustedConnection>
-    <trustedCertificate>true</trustedCertificate>
-  </databaseConfiguration>
-  <showDebugControllers>false</showDebugControllers>
-  <thinClientUrl>http://localhost:3000</thinClientUrl>
-  <githubApiToken>token</githubApiToken>
-  <workflowRunReportThreshold>30</workflowRunReportThreshold>
+	<webApiUrl>https://localhost:44349/</webApiUrl>
+	<databaseConfiguration>
+		<server>localhost\SQLEXPRESS</server>
+		<databaseName>Chasma</databaseName>
+		<trustedConnection>true</trustedConnection>
+		<trustedCertificate>true</trustedCertificate>
+	</databaseConfiguration>
+	<showDebugControllers>false</showDebugControllers>
+	<thinClientUrl>http://localhost:3000</thinClientUrl>
+	<githubApiToken>token</githubApiToken>
+	<workflowRunReportThreshold>30</workflowRunReportThreshold>
 </configurations>

--- a/ChasmaWebApi/Controllers/RepositoryStatusController.cs
+++ b/ChasmaWebApi/Controllers/RepositoryStatusController.cs
@@ -64,11 +64,27 @@ namespace ChasmaWebApi.Controllers
         public ActionResult<GitHubWorkflowRunResponse> GetChasmaWorkflowResults([FromBody] GetWorkflowResultsRequest request)
         {
             GitHubWorkflowRunResponse gitHubWorkflowRunResponse = new();
-            if (request == null || string.IsNullOrEmpty(request.RepositoryName) || string.IsNullOrEmpty(request.RepositoryOwner))
+            if (request == null)
             {
-                logger.LogError("Invalid request received to get workflow run results.");
+                logger.LogError("Null request received to get workflow run results. Sending error response.");
                 gitHubWorkflowRunResponse.IsErrorResponse = true;
-                gitHubWorkflowRunResponse.ErrorMessage = "Invalid request. Repository name and owner are required.";
+                gitHubWorkflowRunResponse.ErrorMessage = "Null request received. Cannot get workflow runs.";
+                return BadRequest(gitHubWorkflowRunResponse);
+            }
+
+            if (string.IsNullOrEmpty(request.RepositoryName))
+            {
+                logger.LogError("Empty repository name received when attempting to get workflow run results. Sending error response.");
+                gitHubWorkflowRunResponse.IsErrorResponse = true;
+                gitHubWorkflowRunResponse.ErrorMessage = "Invalid request. Repository name is required.";
+                return BadRequest(gitHubWorkflowRunResponse);
+            }
+
+            if (string.IsNullOrEmpty(request.RepositoryOwner))
+            {
+                logger.LogError("Empty repository owner received when attempting to get workflow run results. Sending error response.");
+                gitHubWorkflowRunResponse.IsErrorResponse = true;
+                gitHubWorkflowRunResponse.ErrorMessage = "Invalid request. Repository owner is required.";
                 return BadRequest(gitHubWorkflowRunResponse);
             }
 
@@ -205,7 +221,7 @@ namespace ChasmaWebApi.Controllers
         [Route("gitCommit")]
         public ActionResult<GitCommitResponse> CommitChanges([FromBody] GitCommitRequest request)
         {
-            logger.LogInformation("Received request to commit changes for repo: {repoId}", request.RepositoryId);
+            logger.LogInformation("Received request to commit changes");
             GitCommitResponse response = new();
             if (request == null)
             {
@@ -281,7 +297,7 @@ namespace ChasmaWebApi.Controllers
         [Route("gitPush")]
         public ActionResult<GitPushResponse> PushChanges([FromBody] GitPushRequest request)
         {
-            logger.LogInformation("Received request to push changes for repo: {repoId}", request.RepositoryId);
+            logger.LogInformation("Received request to push changes");
             GitPushResponse response = new();
             if (request == null)
             {
@@ -329,7 +345,7 @@ namespace ChasmaWebApi.Controllers
         [Route("gitPull")]
         public ActionResult<GitPullResponse> PullChanges([FromBody] GitPullRequest request)
         {
-            logger.LogInformation("Received request to pull changes for repo: {repoId}", request.RepositoryId);
+            logger.LogInformation("Received request to pull changes");
             GitPullResponse response = new();
             if (request == null)
             {
@@ -346,7 +362,6 @@ namespace ChasmaWebApi.Controllers
                 logger.LogError("Null or empty repository identifier received. Sending error response");
                 return BadRequest(response);
             }
-
 
             string email = request.Email;
             if (string.IsNullOrEmpty(email))
@@ -398,7 +413,7 @@ namespace ChasmaWebApi.Controllers
         [Route("gitCheckout")]
         public ActionResult<GitCheckoutResponse> CheckoutBranch([FromBody] GitCheckoutRequest request)
         {
-            logger.LogInformation("Received request to checkout branch for repo: {repoId}", request.RepositoryId);
+            logger.LogInformation("Received request to checkout branch");
             GitCheckoutResponse response = new();
             if (request == null)
             {

--- a/ChasmaWebApi/Data/Interfaces/IPasswordUtility.cs
+++ b/ChasmaWebApi/Data/Interfaces/IPasswordUtility.cs
@@ -1,0 +1,24 @@
+﻿namespace ChasmaWebApi.Data.Interfaces
+{
+    /// <summary>
+    /// Defines the members of the password utility interface.
+    /// </summary>
+    public interface IPasswordUtility
+    {
+        /// <summary>
+        /// Hash the given password using PBKDF2 with a random salt.
+        /// </summary>
+        /// <param name="password">The plain text password.</param>
+        /// <returns>The hashed password with the salt.</returns>
+        (string Hash, byte[] Salt) HashPassword(string password);
+
+        /// <summary>
+        /// Verifies if the stored hash matches the hash of the given password and salt.
+        /// </summary>
+        /// <param name="password">The login password.</param>
+        /// <param name="salt">The user account salt.</param>
+        /// <param name="storedHash">The database password.</param>
+        /// <returns>True if the passwords match; false otherwise.</returns>
+        bool VerifyPassword(string password, byte[] salt, string storedHash);
+    }
+}

--- a/ChasmaWebApi/Program.cs
+++ b/ChasmaWebApi/Program.cs
@@ -42,6 +42,7 @@ builder.Services.AddCors(options =>
         });
     })
     .AddSingleton(webApiConfigurations)
+    .AddSingleton<IPasswordUtility, PasswordUtility>()
     .AddSingleton<ICacheManager, CacheManager>()
     .AddSingleton<IRepositoryConfigurationManager, RepositoryConfigurationManager>()
     .AddSingleton<IRepositoryStatusManager, RepositoryStatusManager>()

--- a/ChasmaWebApi/Util/PasswordUtility.cs
+++ b/ChasmaWebApi/Util/PasswordUtility.cs
@@ -1,18 +1,15 @@
-﻿using System.Security.Cryptography;
+﻿using ChasmaWebApi.Data.Interfaces;
+using System.Security.Cryptography;
 
 namespace ChasmaWebApi.Util
 {
     /// <summary>
     /// Utility class for password hashing and verification.
     /// </summary>
-    public static class PasswordUtility
+    public class PasswordUtility : IPasswordUtility
     {
-        /// <summary>
-        /// Hash the given password using PBKDF2 with a random salt.
-        /// </summary>
-        /// <param name="password">The plain text password.</param>
-        /// <returns>The hashed password with the salt.</returns>
-        public static (string Hash, byte[] Salt) HashPassword(string password)
+        // <inheritdoc/>
+        public (string Hash, byte[] Salt) HashPassword(string password)
         {
             byte[] salt = new byte[16];
             using RandomNumberGenerator rng = RandomNumberGenerator.Create();
@@ -22,19 +19,12 @@ namespace ChasmaWebApi.Util
             return (hash, salt);
         }
 
-        /// <summary>
-        /// Verifies if the stored hash matches the hash of the given password and salt.
-        /// </summary>
-        /// <param name="password">The login password.</param>
-        /// <param name="salt">The user account salt.</param>
-        /// <param name="storedHash">The database password.</param>
-        /// <returns>True if the passwords match; false otherwise.</returns>
-        public static bool VerifyPassword(string password, byte[] salt, string storedHash)
+        // <inheritdoc/>
+        public bool VerifyPassword(string password, byte[] salt, string storedHash)
         {
             using var pbkdf2 = new Rfc2898DeriveBytes(password, salt, 100000, HashAlgorithmName.SHA256);
             string hash = Convert.ToBase64String(pbkdf2.GetBytes(32));
             return hash == storedHash;
         }
     }
-
 }


### PR DESCRIPTION
Added unit tests for the current implementation of the API controllers. I made sure that I have reached 100% coverage and verified with the dotCover coverage tool:
<img width="995" height="346" alt="image" src="https://github.com/user-attachments/assets/844604b8-59dd-4f41-8a8e-33ab68687b91" />
