### PR TITLE
Chasma-92: Added support to allow user to input custom shell commands from web interface

### DIFF
--- a/ChasmaWebApi.Tests/Controllers/ShellControllerTests.cs
+++ b/ChasmaWebApi.Tests/Controllers/ShellControllerTests.cs
@@ -1,0 +1,186 @@
+﻿using System.Collections.Concurrent;
+using ChasmaWebApi.Controllers;
+using ChasmaWebApi.Data.Interfaces;
+using ChasmaWebApi.Data.Requests.Shell;
+using ChasmaWebApi.Data.Responses.Shell;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace ChasmaWebApi.Tests.Controllers;
+
+/// <summary>
+/// Class testing the functionality of the <see cref="ShellController"/>.
+/// </summary>
+[TestClass]
+public class ShellControllerTests : ControllerTestBase<ShellController>
+{
+    /// <summary>
+    /// The mocked implementation of the internal API logger.
+    /// </summary>
+    private readonly Mock<ILogger<ShellController>> loggerMock;
+    
+    /// <summary>
+    /// The mocked implementation of the internal Shell Manager.
+    /// </summary>
+    private readonly Mock<IShellManager> shellManagerMock;
+    
+    /// <summary>
+    /// The mocked implementation of the internal cache manager.
+    /// </summary>
+    private readonly Mock<ICacheManager> cacheManagerMock;
+
+    #region Constructor
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ShellControllerTests"/> class.
+    /// </summary>
+    public ShellControllerTests()
+    {
+        loggerMock = new Mock<ILogger<ShellController>>();
+        shellManagerMock = new Mock<IShellManager>();
+        cacheManagerMock = new Mock<ICacheManager>();
+    }
+
+    #endregion
+    
+    /// <summary>
+    /// Set up the tests before each case is run.
+    /// </summary>
+    [TestInitialize]
+    public void Setup()
+    {
+        Controller = new ShellController(loggerMock.Object, shellManagerMock.Object, cacheManagerMock.Object);
+    }
+    
+    /// <summary>
+    /// Cleans up the resources after each test.
+    /// </summary>
+    [TestCleanup]
+    public void Cleanup()
+    {
+        loggerMock.Reset();
+        shellManagerMock.Reset();
+        cacheManagerMock.Reset();
+    }
+    
+    /// <summary>
+    /// Tests that the <see cref="ShellController.ExecuteShellCommands(ExecuteShellCommandRequest)"/> sends an error
+    /// response when the incoming request is null.
+    /// </summary>
+    [TestMethod]
+    public void TestExecuteShellCommandsWithNullRequest()
+    {
+        ActionResult<ExecuteShellCommandResponse> actionResult = Controller.ExecuteShellCommands(null!);
+        ExecuteShellCommandResponse response =  GetResponseFromHttpAction(actionResult, typeof(BadRequestObjectResult));
+        Assert.IsTrue(response.IsErrorResponse);
+        Assert.AreEqual("Request is null. Cannot execute commands.", response.ErrorMessage);
+    }
+    
+    /// <summary>
+    /// Tests that the <see cref="ShellController.ExecuteShellCommands(ExecuteShellCommandRequest)"/> sends an error
+    /// response when the incoming request has an empty repository identifier.
+    /// </summary>
+    [TestMethod]
+    public void TestExecuteShellCommandsWithEmptyRepositoryId()
+    {
+        ExecuteShellCommandRequest request = new();
+        ActionResult<ExecuteShellCommandResponse> actionResult = Controller.ExecuteShellCommands(request);
+        ExecuteShellCommandResponse response =  GetResponseFromHttpAction(actionResult, typeof(BadRequestObjectResult));
+        Assert.IsTrue(response.IsErrorResponse);
+        Assert.AreEqual("RepositoryId is required to execute shell commands.", response.ErrorMessage);
+    }
+    
+    /// <summary>
+    /// Tests that the <see cref="ShellController.ExecuteShellCommands(ExecuteShellCommandRequest)"/> sends an error
+    /// response when the incoming request has a repository identifier that does not have a working directory.
+    /// </summary>
+    [TestMethod]
+    public void TestExecuteShellCommandsWithWorkingDirectoryNotFound()
+    {
+        ConcurrentDictionary<string, string> workingDirectories = new();
+        cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+        ExecuteShellCommandRequest request = new() {RepositoryId = Guid.NewGuid().ToString()};
+        ActionResult<ExecuteShellCommandResponse> actionResult = Controller.ExecuteShellCommands(request);
+        ExecuteShellCommandResponse response =  GetResponseFromHttpAction(actionResult, typeof(BadRequestObjectResult));
+        Assert.IsTrue(response.IsErrorResponse);
+        Assert.AreEqual("No working directory was found for the specified repository.", response.ErrorMessage);
+    }
+    
+    /// <summary>
+    /// Tests that the <see cref="ShellController.ExecuteShellCommands(ExecuteShellCommandRequest)"/> sends an error
+    /// response when the incoming request has a repository identifier that does not have any commands to execute.
+    /// </summary>
+    [TestMethod]
+    public void TestExecuteShellCommandsWithNoCommandsToExecute()
+    {
+        string repositoryId = Guid.NewGuid().ToString();
+        ConcurrentDictionary<string, string> workingDirectories = new()
+        {
+            [repositoryId] = "working_directory"
+        };
+        cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+        ExecuteShellCommandRequest request = new() {RepositoryId = repositoryId};
+        ActionResult<ExecuteShellCommandResponse> actionResult = Controller.ExecuteShellCommands(request);
+        ExecuteShellCommandResponse response =  GetResponseFromHttpAction(actionResult, typeof(BadRequestObjectResult));
+        Assert.IsTrue(response.IsErrorResponse);
+        Assert.AreEqual("No shell commands were provided to execute.", response.ErrorMessage);
+    }
+    
+    /// <summary>
+    /// Tests that the <see cref="ShellController.ExecuteShellCommands(ExecuteShellCommandRequest)"/> sends an error
+    /// response when executing the commands produces an exception.
+    /// </summary>
+    [TestMethod]
+    public void TestExecuteShellCommandsWithUnexpectedException()
+    {
+        string repositoryId = Guid.NewGuid().ToString();
+        ConcurrentDictionary<string, string> workingDirectories = new()
+        {
+            [repositoryId] = "working_directory"
+        };
+        cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+        List<string> commands = ["git status", "git push"];
+        ExecuteShellCommandRequest request = new()
+        {
+            RepositoryId = repositoryId,
+            Commands = commands
+        };
+        shellManagerMock.Setup(i => i.ExecuteShellCommands(It.IsAny<string>(), commands)).Throws(new Exception());
+        ActionResult<ExecuteShellCommandResponse> actionResult = Controller.ExecuteShellCommands(request);
+        ExecuteShellCommandResponse response =  GetResponseFromHttpAction(actionResult, typeof(OkObjectResult));
+        Assert.IsTrue(response.IsErrorResponse);
+        Assert.AreEqual("Error executing shell commands. Check internal server logs for more information.", response.ErrorMessage);
+    }
+    
+    /// <summary>
+    /// Tests that the <see cref="ShellController.ExecuteShellCommands(ExecuteShellCommandRequest)"/> sends a successful
+    /// response in the nominal case of executing shell commands.
+    /// </summary>
+    [TestMethod]
+    public void TestExecuteShellCommandsNominalCase()
+    {
+        string repositoryId = Guid.NewGuid().ToString();
+        ConcurrentDictionary<string, string> workingDirectories = new()
+        {
+            [repositoryId] = "working_directory"
+        };
+        cacheManagerMock.SetupGet(i => i.WorkingDirectories).Returns(workingDirectories);
+
+        List<string> commands = ["git status", "git push"];
+        ExecuteShellCommandRequest request = new()
+        {
+            RepositoryId = repositoryId,
+            Commands = commands
+        };
+
+        List<string> outputMessages = ["git status was successfully executed.", "git push failed to execute."];
+        shellManagerMock.Setup(i => i.ExecuteShellCommands(It.IsAny<string>(), commands)).Returns(outputMessages);
+
+        ActionResult<ExecuteShellCommandResponse> actionResult = Controller.ExecuteShellCommands(request);
+        ExecuteShellCommandResponse response =  GetResponseFromHttpAction(actionResult, typeof(OkObjectResult));
+        Assert.IsFalse(response.IsErrorResponse);
+        CollectionAssert.Contains(response.OutputMessages, outputMessages[0]);
+        CollectionAssert.Contains(response.OutputMessages, outputMessages[1]);
+    }
+}

--- a/ChasmaWebApi/.editorconfig
+++ b/ChasmaWebApi/.editorconfig
@@ -5,3 +5,6 @@ dotnet_diagnostic.CS8618.severity = none
 
 # CS8600: Converting null literal or possible null value to non-nullable type.
 dotnet_diagnostic.CS8600.severity = none
+
+# CS9107: Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor. The value might be captured by the base class as well.
+dotnet_diagnostic.CS9107.severity = none

--- a/ChasmaWebApi/ChasmaWebOpenApiSpec.json
+++ b/ChasmaWebApi/ChasmaWebOpenApiSpec.json
@@ -540,6 +540,38 @@
         }
       }
     },
+    "/api/Shell/executeShellCommands": {
+      "post": {
+        "tags": [
+          "Shell"
+        ],
+        "operationId": "Shell_ExecuteShellCommands",
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExecuteShellCommandRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecuteShellCommandResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/User/login": {
       "post": {
         "tags": [
@@ -1431,6 +1463,47 @@
               },
               "body": {
                 "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "ExecuteShellCommandResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResponseBase"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "outputMessages": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "ExecuteShellCommandRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ChasmaXmlBase"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "repositoryId": {
+                "type": "string"
+              },
+              "commands": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/ChasmaWebApi/Controllers/ShellController.cs
+++ b/ChasmaWebApi/Controllers/ShellController.cs
@@ -1,0 +1,96 @@
+﻿using ChasmaWebApi.Data.Interfaces;
+using ChasmaWebApi.Data.Requests.Shell;
+using ChasmaWebApi.Data.Responses.Shell;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ChasmaWebApi.Controllers
+{
+    /// <summary>
+    /// Class describing the controller used to interact with the system shell.
+    /// </summary>
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="ShellController"/> class.
+    /// </remarks>
+    /// <param name="internalLogger">The internal API logger.</param>
+    /// <param name="manager">The internal API shell manager.</param>
+    /// <param name="internalCacheManager">The internal API cache manager.</param>
+    [Route("api/[controller]")]
+    public class ShellController(ILogger<ShellController> internalLogger, IShellManager manager, ICacheManager internalCacheManager) : ControllerBase
+    {
+        /// <summary>
+        /// The internal API logger.
+        /// </summary>
+        private readonly ILogger<ShellController> logger = internalLogger;
+
+        /// <summary>
+        /// The internal API shell manager.
+        /// </summary>
+        private readonly IShellManager shellManager = manager;
+
+        /// <summary>
+        /// The internal API cache manager.
+        /// </summary>
+        private readonly ICacheManager cacheManager = internalCacheManager;
+
+        /// <summary>
+        /// Executes custom shell commands on the current system's shell.
+        /// </summary>
+        /// <param name="request">The execute shell commands request.</param>
+        /// <returns>The response summary of executing shell commands.</returns>
+        [HttpPost]
+        [Route("executeShellCommands")]
+        public ActionResult<ExecuteShellCommandResponse> ExecuteShellCommands([FromBody] ExecuteShellCommandRequest request)
+        {
+            logger.LogInformation("Received {request} to execute shell commands.", nameof(ExecuteShellCommandRequest));
+            ExecuteShellCommandResponse response = new();
+            if (request == null)
+            {
+                logger.LogError("Received null request when attempting to execute shell commands. Sending error response.");
+                response.IsErrorResponse = true;
+                response.ErrorMessage = "Request is null. Cannot execute commands.";
+                return BadRequest(response);
+            }
+
+            string repositoryId = request.RepositoryId;
+            if (string.IsNullOrEmpty(repositoryId))
+            {
+                logger.LogError("RepositoryId is missing in the request. Sending error response.");
+                response.IsErrorResponse = true;
+                response.ErrorMessage = "RepositoryId is required to execute shell commands.";
+                return BadRequest(response);
+            }
+
+            if (!cacheManager.WorkingDirectories.TryGetValue(repositoryId, out string workingDirectory))
+            {
+                logger.LogError("No working directory was found for repository {repoId}, so shell commands could not be sent. Sending error response.", repositoryId);
+                response.IsErrorResponse = true;
+                response.ErrorMessage = "No working directory was found for the specified repository.";
+                return BadRequest(response);
+            }
+
+            List<string> commands = request.Commands;
+            if (commands.Count == 0)
+            {
+                response.IsErrorResponse = true;
+                response.ErrorMessage = "No shell commands were provided to execute.";
+                logger.LogError("No shell commands provided in the request. Sending error response.");
+                return BadRequest(response);
+            }
+
+            try
+            {
+                List<string> outputMessages = shellManager.ExecuteShellCommands(workingDirectory, commands);
+                response.OutputMessages = outputMessages;
+                logger.LogInformation("Successfully executed shell commands without any exceptions. Sending response.");
+                return Ok(response);
+            }
+            catch (Exception ex)
+            {
+                response.IsErrorResponse = true;
+                response.ErrorMessage = "Error executing shell commands. Check internal server logs for more information.";
+                logger.LogError("An exception occurred while executing commands: {errorMessage}", ex.Message);
+                return Ok(response);
+            }
+        }
+    }
+}

--- a/ChasmaWebApi/Data/Interfaces/IShellManager.cs
+++ b/ChasmaWebApi/Data/Interfaces/IShellManager.cs
@@ -1,0 +1,16 @@
+﻿namespace ChasmaWebApi.Data.Interfaces
+{
+    /// <summary>
+    /// Class defining the members required for a shell manager.
+    /// </summary>
+    public interface IShellManager
+    {
+        /// <summary>
+        /// Executes the list of git command in the system shell.
+        /// </summary>
+        /// <param name="workingDirectory">The working directory to execute the commands in.</param>
+        /// <param name="shellCommands">The shell commands to execute.</param>
+        /// <returns>The list of output messages from the executed commands.</returns>
+        List<string> ExecuteShellCommands(string workingDirectory, IEnumerable<string> shellCommands);
+    }
+}

--- a/ChasmaWebApi/Data/Managers/ShellManager.cs
+++ b/ChasmaWebApi/Data/Managers/ShellManager.cs
@@ -1,0 +1,60 @@
+﻿using ChasmaWebApi.Data.Interfaces;
+using System.Diagnostics;
+
+namespace ChasmaWebApi.Data.Managers
+{
+    /// <summary>
+    /// Provides functionality for executing shell commands, specifically Git commands, and managing related client
+    /// operations within the application.
+    /// </summary>
+    /// <param name="logger">The internal API logger.</param>
+    /// <param name="cacheManager">The internal cache manager.</param>
+    public class ShellManager(ILogger<ShellManager> logger, ICacheManager cacheManager)
+        : ClientManagerBase<ShellManager>(logger, cacheManager), IShellManager
+    {
+        // <inheritdoc/>
+        public List<string> ExecuteShellCommands(string workingDirectory, IEnumerable<string> shellCommands)
+        {
+            List<string> outputMessages = [];
+            try
+            {
+                foreach (string command in shellCommands)
+                {
+                    ProcessStartInfo processInfo = new("cmd.exe", $"/c {command}")
+                    {
+                        WorkingDirectory = workingDirectory,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                    };
+                    using Process process = new() { StartInfo = processInfo };
+                    process.Start();
+                    string output = process.StandardOutput.ReadToEnd();
+                    string error = process.StandardError.ReadToEnd();
+                    process.WaitForExit();
+                    if (process.ExitCode != 0)
+                    {
+                        string errorMessage = $"Command '{command}' failed with error: {error}\n";
+                        logger.LogError(errorMessage);
+                        outputMessages.Add(errorMessage);
+                    }
+                    else
+                    {
+                        string successMessage = $"Command '{command}' executed successfully: {output}\n";
+                        logger.LogInformation(successMessage);
+                        outputMessages.Add(successMessage);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                string errorMessage = $"An exception occurred while executing commands: {ex.Message}";
+                logger.LogError(ex, errorMessage);
+                outputMessages.Add(errorMessage);
+            }
+
+            return outputMessages;
+        }
+    }
+}

--- a/ChasmaWebApi/Data/Requests/Shell/ExecuteShellCommandRequest.cs
+++ b/ChasmaWebApi/Data/Requests/Shell/ExecuteShellCommandRequest.cs
@@ -1,0 +1,20 @@
+﻿using ChasmaWebApi.Util;
+
+namespace ChasmaWebApi.Data.Requests.Shell
+{
+    /// <summary>
+    /// Class representing a request to execute a shell command.
+    /// </summary>
+    public class ExecuteShellCommandRequest : ChasmaXmlBase
+    {
+        /// <summary>
+        /// Gets or sets the repository identifier.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of shell commands to execute.
+        /// </summary>
+        public List<string> Commands { get; set; } = new();
+    }
+}

--- a/ChasmaWebApi/Data/Responses/Shell/ExecuteShellCommandResponse.cs
+++ b/ChasmaWebApi/Data/Responses/Shell/ExecuteShellCommandResponse.cs
@@ -1,0 +1,13 @@
+﻿namespace ChasmaWebApi.Data.Responses.Shell
+{
+    /// <summary>
+    /// Class representing a response after executing a shell command.
+    /// </summary>
+    public class ExecuteShellCommandResponse : ResponseBase
+    {
+        /// <summary>
+        /// Gets or sets the output message from the command execution.
+        /// </summary>
+        public List<string> OutputMessages { get; set; } = new();
+    }
+}

--- a/ChasmaWebApi/Program.cs
+++ b/ChasmaWebApi/Program.cs
@@ -53,6 +53,7 @@ builder.Services.AddCors(options =>
     .AddSingleton<ICacheManager, CacheManager>()
     .AddSingleton<IRepositoryConfigurationManager, RepositoryConfigurationManager>()
     .AddSingleton<IRepositoryStatusManager, RepositoryStatusManager>()
+    .AddSingleton<IShellManager, ShellManager>()
     .AddEndpointsApiExplorer()
     .AddOpenApiDocument(config =>
     {

--- a/chasma-thin-client/src/components/modals/ExecuteShellCommandsModal.tsx
+++ b/chasma-thin-client/src/components/modals/ExecuteShellCommandsModal.tsx
@@ -1,0 +1,204 @@
+﻿import React, {useCallback, useState} from "react";
+import {Row} from "../types/CustomTypes"
+import {ExecuteShellCommandRequest, ShellClient} from "../../API/ChasmaWebApiClient";
+import {apiBaseUrl} from "../../environmentConstants";
+import {isBlankOrUndefined} from "../../stringHelperUtil";
+
+/**
+ * The members of the execute shell commands modal.
+ */
+interface IExecuteShellCommandsProps {
+    /** Function to call when the modal is being closed. **/
+    onClose: () => void,
+
+    /** The repository identifier to execute shell commands in. **/
+    repositoryId: string | undefined
+}
+
+/** The shell client used to interact with the API. **/
+const shellClient = new ShellClient(apiBaseUrl);
+
+/**
+ * Initializes a new ExecuteShellCommandsModal class.
+ * @param props The properties to execute shell commands in repositories.
+ * @constructor
+ */
+const ExecuteShellCommandsModal: React.FC<IExecuteShellCommandsProps> = (props: IExecuteShellCommandsProps) => {
+    /** Gets or sets the shell command rows. **/
+    const [rows, setRows] = useState<Row[]>([]);
+
+    /** Gets or sets the error message. **/
+    const [errorMessage, setErrorMessage] = React.useState<string | undefined>(undefined);
+
+    /** Gets or sets a flag indicating whether the commands have been executed. **/
+    const [commandsExecuted, setCommandsExecuted] = React.useState<boolean>(false);
+
+    /** Gets or sets the command output after the commands have been executed. **/
+    const [output, setOutput] = React.useState<string>("");
+
+    /** Adds a shell command row to the form. **/
+    const addCustomShellCommandRow = () => {
+        setRows(prev => [
+            ...prev,
+            {id: crypto.randomUUID(), first: "", second: ""}
+        ])};
+
+    /** Handles custom shell command row changes in the form. **/
+    const handleShellCommandChange = (
+            id: string,
+            field: "first" | "second",
+            value: string
+    ) => {
+            setRows(prev =>
+                prev.map(row =>
+                    row.id === id ? { ...row, [field]: value } : row
+                )
+            );
+        };
+
+   /**
+   * Handles the request execute custom commands in the API shell.
+   **/
+   const handleExecuteShellCommandsRequest = useCallback(async (e: React.FormEvent) => {
+       e.preventDefault();
+       const request = new ExecuteShellCommandRequest();
+       request.repositoryId = props.repositoryId;
+       request.commands = [];
+       rows.forEach(row => {
+       if (!isBlankOrUndefined(row.first) && request.commands) {
+           request.commands.push(row.first);
+        }
+       });
+
+       try {
+           const response = await shellClient.executeShellCommands(request);
+           if (response.isErrorResponse) {
+               setErrorMessage(response.errorMessage);
+               setCommandsExecuted(false);
+               setOutput("");
+               return;
+           }
+
+           const commandOutput = response.outputMessages
+               ? response.outputMessages.map(i => i).join("\n")
+               : "";
+           setOutput(commandOutput);
+       } catch (e) {
+           console.error(e);
+           setOutput("")
+           setErrorMessage("Error executing shell commands. Check console logs for more information.")
+       }
+       finally {
+           setCommandsExecuted(true);
+       }}, [rows]);
+
+    /** Resets the form to a pre-filled state. **/
+    function resetForm() {
+        setRows([]);
+        setOutput("");
+        setCommandsExecuted(false);
+        setErrorMessage(undefined);
+    }
+
+    /**
+     * Deletes the row with the specified row identifier.
+     * @param rowId The row identifier.
+     */
+    function deleteShellCommandRow(rowId: string) {
+        const filteredRows = rows.filter(row => row.id !== rowId);
+        setRows(filteredRows);
+    }
+
+    return (
+            <>
+                <div className="modal-backdrop" onClick={props.onClose}>
+                    <div className="commit-modal" onClick={(e) => e.stopPropagation()}>
+
+                        {!commandsExecuted && (
+                            <>
+                                <div className="header-row">
+                                    {errorMessage && <h3 className="commit-modal-message">{errorMessage}</h3>}
+                                    <h2>Enter shell commands</h2>
+                                    <button
+                                        type="button"
+                                        id="addClaimButton"
+                                        className="circle-button"
+                                        onClick={addCustomShellCommandRow}
+                                    >
+                                        +
+                                    </button>
+                                </div>
+                                <br/>
+                                <div id="customClaimsContainer">
+                                    {rows.map(row => (
+                                        <div
+                                            key={row.id}
+                                            style={{
+                                                display: "flex",
+                                                gap: "10px",
+                                                marginBottom: "10px"
+                                            }}
+                                        >
+                                            <input
+                                                type="text"
+                                                placeholder="Example: git log --oneline"
+                                                className="input-field"
+                                                value={row.first}
+                                                onChange={e => handleShellCommandChange(row.id, "first", e.target.value)}/>
+                                            <button
+                                                className="delete-button"
+                                                type="button"
+                                                onClick={() => deleteShellCommandRow(row.id)}
+                                            >
+                                                Remove
+                                            </button>
+                                        </div>
+                                    ))}
+                                    <br/>
+                                </div>
+                                <div>
+                                    <button className="commit-modal-button"
+                                            style={{marginRight: "50px"}}
+                                            onClick={handleExecuteShellCommandsRequest}
+                                    >
+                                        Execute Commands
+                                    </button>
+                                    <button className="commit-modal-button"
+                                            onClick={props.onClose}
+                                    >
+                                        Close
+                                    </button>
+                                </div>
+                            </>
+                        )}
+                        {commandsExecuted && (
+                            <>
+                                <div className="commit-modal-title">
+                                    <h2>Console Output</h2>
+                                </div>
+                                <textarea className="input-area"
+                                        value={output}
+                                        readOnly={true}/>
+                                <br/>
+                                <div>
+                                    <button className="commit-modal-button"
+                                            style={{marginRight: "50px"}}
+                                            onClick={resetForm}
+                                    >
+                                        Restart
+                                    </button>
+                                    <button className="commit-modal-button"
+                                            onClick={props.onClose}
+                                    >
+                                        Close
+                                    </button>
+                                </div>
+                            </>
+                        )}
+                    </div>
+                </div>
+            </>
+        )
+}
+
+export default ExecuteShellCommandsModal;

--- a/chasma-thin-client/src/components/pages/RepositoryStatusPage.tsx
+++ b/chasma-thin-client/src/components/pages/RepositoryStatusPage.tsx
@@ -18,6 +18,7 @@ import PullRequestModal from "../modals/PullRequestModal";
 import CreateIssueModal from "../modals/CreateIssueModal";
 import DeleteBranchModal from "../modals/DeleteBranchModal";
 import {apiBaseUrl} from "../../environmentConstants";
+import ExecuteShellCommandsModal from "../modals/ExecuteShellCommandsModal";
 
 /** The status client for the web API. **/
 const statusClient = new RepositoryStatusClient(apiBaseUrl);
@@ -58,6 +59,9 @@ const RepositoryStatusPage: React.FC = () => {
 
     /** Gets or sets a flag indicating whether the user is deleting a branch. **/
     const [isDeletingBranch, setIsDeletingBranch] = useState<boolean>(false);
+
+    /** Gets or sets a flag indicating whether the user executing shell commands. **/
+    const [isExecutingShellCommands, setIsExecutingShellCommands] = useState<boolean>(false);
 
     /** Gets or sets the number of commits the local repo is ahead of the remote. **/
     const [commitsAhead, setCommitsAhead] = useState<number | undefined>(0);
@@ -264,6 +268,12 @@ const RepositoryStatusPage: React.FC = () => {
                 >
                     Create Issue
                 </div>
+                <br/>
+                <div className="tab"
+                     onClick={() => setIsExecutingShellCommands(true)}
+                >
+                    Custom Shell Commands
+                </div>
             </aside>
             <h1 className="repository-title-header">
                 {repoName} Status Manager
@@ -382,6 +392,11 @@ const RepositoryStatusPage: React.FC = () => {
             {isDeletingBranch && (
                 <DeleteBranchModal
                     onClose={() => setIsDeletingBranch(false)}
+                    repositoryId={repoId} />
+            )}
+            {isExecutingShellCommands && (
+                <ExecuteShellCommandsModal
+                    onClose={() => setIsExecutingShellCommands(false)}
                     repositoryId={repoId} />
             )}
         </>

--- a/chasma-thin-client/src/css/Dashboard.css
+++ b/chasma-thin-client/src/css/Dashboard.css
@@ -361,3 +361,19 @@ html, body {
 .context-menu li:hover {
     background: #333;
 }
+
+.delete-button {
+    padding: 12px;
+    background-color: red;
+    color: #ffffff;
+    font-size: 16px;
+    border: none;
+    border-radius: 6px;
+    margin-bottom: 18px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.delete-button:hover {
+    background-color: darkred;
+}


### PR DESCRIPTION
### Test Steps
1. Login to GitCtrl.
2. Select repository of choice for testing.
3. In the left panel, select the `Custom Shell Commands` tab.
4. In the popup, select the `+` button to be able to add a shell command.
5. Try numerous commands such as `git status`, `git log --oneline`,`git branch`, etc.
6. Verify when you select the `Execute Commands` button, you are switched to the `Console Output` view and the command summary is shown in the text box.
7. Click `Restart` to start the process over.

### Unit Test Coverage Summary
<img width="1246" height="151" alt="image" src="https://github.com/user-attachments/assets/6aad38ee-6a5d-47c9-b2a7-370842085b11" />