### PR TITLE
Chasma-115: Updated which files are copied to output directory

### DIFF
--- a/ChasmaWebApi.Tests/ChasmaWebApi.Tests.csproj
+++ b/ChasmaWebApi.Tests/ChasmaWebApi.Tests.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <None Update="config.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/ChasmaWebApi/ChasmaWebApi.csproj
+++ b/ChasmaWebApi/ChasmaWebApi.csproj
@@ -32,6 +32,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Update="ChasmaWebOpenApiSpec.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Content>
+    <Content Update="nswag.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="config.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
The changes here will determine which files are copied to the output directory. We pretty much only want the `config.xml` file to be present that the user can interact with.