### PR TITLE
Chasma-126: Fixed bug that only shows one current state in diff

### DIFF
--- a/ChasmaWebApi.Tests/Controllers/RepositoryStatusControllerTests.cs
+++ b/ChasmaWebApi.Tests/Controllers/RepositoryStatusControllerTests.cs
@@ -1698,6 +1698,7 @@ namespace ChasmaWebApi.Tests.Controllers
             statusManagerMock.Setup(i =>i.TryGetGitDiff(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 out diffContent,
                 out errorMessage)
                 ).Returns(false);
@@ -1731,6 +1732,7 @@ namespace ChasmaWebApi.Tests.Controllers
             statusManagerMock.Setup(i =>i.TryGetGitDiff(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<bool>(),
                 out diffContent,
                 out errorMessage)
             ).Returns(true);

--- a/ChasmaWebApi/ChasmaWebOpenApiSpec.json
+++ b/ChasmaWebApi/ChasmaWebOpenApiSpec.json
@@ -1530,6 +1530,9 @@
               },
               "filePath": {
                 "type": "string"
+              },
+              "isStaged": {
+                "type": "boolean"
               }
             }
           }

--- a/ChasmaWebApi/Controllers/RepositoryStatusController.cs
+++ b/ChasmaWebApi/Controllers/RepositoryStatusController.cs
@@ -754,7 +754,8 @@ namespace ChasmaWebApi.Controllers
             }
 
             logger.LogInformation("Received request to get git diff for repository ID: {repoId}, file path: {filePath}", repoId, filePath);
-            if (!statusManager.TryGetGitDiff(workingDirectory, filePath, out string diffContent, out string errorMessage))
+            bool isStaged = gitDiffRequest.IsStaged;
+            if (!statusManager.TryGetGitDiff(workingDirectory, filePath, isStaged, out string diffContent, out string errorMessage))
             {
                 logger.LogError(errorMessage);
                 response.IsErrorResponse = true;

--- a/ChasmaWebApi/Data/Interfaces/IRepositoryStatusManager.cs
+++ b/ChasmaWebApi/Data/Interfaces/IRepositoryStatusManager.cs
@@ -118,9 +118,10 @@ namespace ChasmaWebApi.Data.Interfaces
         /// </summary>
         /// <param name="workingDirectory">The working directory of file to get the diff of.</param>
         /// <param name="filePath">The path to the file to be diffed.</param>
+        /// <param name="isStaged">Flag indicating whether to get the diff for the staged version of the file.</param>
         /// <param name="diffContent">The content as a result of the git diff operation.</param>
         /// <param name="errorMessage">The error message if an error occurs.</param>
         /// <returns>True if the file was successfully diffed; false otherwise.</returns>
-        bool TryGetGitDiff(string workingDirectory, string filePath, out string diffContent, out string errorMessage);
+        bool TryGetGitDiff(string workingDirectory, string filePath, bool isStaged, out string diffContent, out string errorMessage);
     }
 }

--- a/ChasmaWebApi/Data/Requests/Status/GitDiffRequest.cs
+++ b/ChasmaWebApi/Data/Requests/Status/GitDiffRequest.cs
@@ -16,5 +16,10 @@ namespace ChasmaWebApi.Data.Requests.Status
         /// Gets or sets the file path to get the diff for.
         /// </summary>
         public string FilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to get the staged changes or unstaged changes.
+        /// </summary>
+        public bool IsStaged { get; set; }
     }
 }

--- a/chasma-thin-client/src/components/pages/RepositoryStatusPage.tsx
+++ b/chasma-thin-client/src/components/pages/RepositoryStatusPage.tsx
@@ -144,7 +144,7 @@ const RepositoryStatusPage: React.FC = () => {
         const interval = setInterval(() => {
             handleGitStatusRequest();
             if (selectedFile !== null) {
-                handleGetGitDiffRequest(selectedFile)
+                handleGetGitDiffRequest(selectedFile, selectedFile.isStaged)
             }
         }, 2500);
         return () => clearInterval(interval);
@@ -208,6 +208,7 @@ const RepositoryStatusPage: React.FC = () => {
             } else {
                 file.isStaged = stagingAction;
                 setSelectedFile(file);
+                await handleGetGitDiffRequest(file, stagingAction);
             }
         } catch {
             setNotification({
@@ -269,12 +270,14 @@ const RepositoryStatusPage: React.FC = () => {
     /**
      * Handles the event when the user wants to get the diff of a file.
      * @param file The file to be diffed.
+     * @param isStaged Flag indicating whether the file is in the staging area.
      */
-    async function handleGetGitDiffRequest(file: RepositoryStatusElement) {
+    async function handleGetGitDiffRequest(file: RepositoryStatusElement, isStaged: boolean | undefined) {
         if (!repoId) return;
         const request = new GitDiffRequest();
         request.repositoryId = repoId;
         request.filePath = file.filePath;
+        request.isStaged = isStaged;
         try {
             const response = await statusClient.getGitDiff(request);
             if (response.isErrorResponse) {
@@ -291,10 +294,11 @@ const RepositoryStatusPage: React.FC = () => {
     /**
      * Handles the event when the user clicks a file from the unstaged/staged changes.
      * @param file The file to be selected.
+     * @param isStaged Flag indicating whether the file is in the staging area.
      */
-    const handleSelectFile = (file: RepositoryStatusElement) => {
+    const handleSelectFile = (file: RepositoryStatusElement, isStaged: boolean) => {
         setSelectedFile(file);
-        handleGetGitDiffRequest(file);
+        handleGetGitDiffRequest(file, isStaged);
     };
 
     /** The parsed unified diff. */
@@ -336,7 +340,7 @@ const RepositoryStatusPage: React.FC = () => {
                             {statusElements?.filter(e => e.isStaged).map((element, index) => (
                                 <tbody key={index}>
                                 <tr>
-                                    <td onClick={() => handleSelectFile(element)}>{element.filePath}</td>
+                                    <td onClick={() => handleSelectFile(element, true)}>{element.filePath}</td>
                                 </tr>
                                 </tbody>
                             ))}
@@ -348,7 +352,7 @@ const RepositoryStatusPage: React.FC = () => {
                             {statusElements?.filter(e => !e.isStaged).map((element, index) => (
                                 <tbody key={index}>
                                 <tr>
-                                    <td onClick={() => handleSelectFile(element)}>{element.filePath}</td>
+                                    <td onClick={() => handleSelectFile(element, false)}>{element.filePath}</td>
                                 </tr>
                                 </tbody>
                             ))}


### PR DESCRIPTION
These changes fix the scenario:
Given the scenario:
- I stage fileA
- I update fileA to include another line
- Web application still shows file as staged and not staged and unstaged since there are new changes that have not been staged yet.