### PR TITLE
Chasma-109: Added support for executing batch shell commands

### DIFF
--- a/ChasmaWebApi/ChasmaWebOpenApiSpec.json
+++ b/ChasmaWebApi/ChasmaWebOpenApiSpec.json
@@ -604,6 +604,38 @@
         }
       }
     },
+    "/api/Shell/executeBatchShellCommands": {
+      "post": {
+        "tags": [
+          "Shell"
+        ],
+        "operationId": "Shell_ExecuteBatchShellCommands",
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExecuteBatchShellCommandsRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecuteBatchShellCommandsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/User/login": {
       "post": {
         "tags": [
@@ -1578,6 +1610,81 @@
             }
           }
         ]
+      },
+      "ExecuteBatchShellCommandsResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResponseBase"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "results": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BatchCommandEntryResult"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "BatchCommandEntryResult": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ChasmaXmlBase"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "repositoryName": {
+                "type": "string"
+              },
+              "isSuccess": {
+                "type": "boolean"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "ExecuteBatchShellCommandsRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ChasmaXmlBase"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "batchCommands": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BatchCommandEntry"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "BatchCommandEntry": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "repositoryId": {
+            "type": "string"
+          },
+          "commands": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
       },
       "LoginResponse": {
         "allOf": [

--- a/ChasmaWebApi/Data/Interfaces/IShellManager.cs
+++ b/ChasmaWebApi/Data/Interfaces/IShellManager.cs
@@ -1,4 +1,6 @@
-﻿namespace ChasmaWebApi.Data.Interfaces
+﻿using ChasmaWebApi.Data.Objects;
+
+namespace ChasmaWebApi.Data.Interfaces
 {
     /// <summary>
     /// Class defining the members required for a shell manager.
@@ -12,5 +14,12 @@
         /// <param name="shellCommands">The shell commands to execute.</param>
         /// <returns>The list of output messages from the executed commands.</returns>
         List<string> ExecuteShellCommands(string workingDirectory, IEnumerable<string> shellCommands);
+
+        /// <summary>
+        /// Executes the list of shell commands in batch for multiple working directories.
+        /// </summary>
+        /// <param name="entries">The entries to execute batch commands for.</param>
+        /// <returns>The results of the batch commands.</returns>
+        List<BatchCommandEntryResult> ExecuteShellCommandsInBatch(IEnumerable<BatchCommandEntry> entries);
     }
 }

--- a/ChasmaWebApi/Data/Objects/BatchCommandEntry.cs
+++ b/ChasmaWebApi/Data/Objects/BatchCommandEntry.cs
@@ -1,0 +1,18 @@
+﻿namespace ChasmaWebApi.Data.Objects
+{
+    /// <summary>
+    /// Class representing a batch command entry.
+    /// </summary>
+    public class BatchCommandEntry
+    {
+        /// <summary>
+        /// Gets or sets the repository identifier.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of commands to execute.
+        /// </summary>
+        public List<string> Commands { get; set; } = new();
+    }
+}

--- a/ChasmaWebApi/Data/Objects/BatchCommandEntryResult.cs
+++ b/ChasmaWebApi/Data/Objects/BatchCommandEntryResult.cs
@@ -1,0 +1,25 @@
+﻿using ChasmaWebApi.Util;
+
+namespace ChasmaWebApi.Data.Objects
+{
+    /// <summary>
+    /// Class representing the result of a batch command entry.
+    /// </summary>
+    public class BatchCommandEntryResult : ChasmaXmlBase
+    {
+        /// <summary>
+        /// Gets or sets the name of the repository.
+        /// </summary>
+        public string RepositoryName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the command execution was successful.
+        /// </summary>
+        public bool IsSuccess { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message associated with the command execution.
+        /// </summary>
+        public string Message { get; set; }
+    }
+}

--- a/ChasmaWebApi/Data/Requests/Shell/ExecuteBatchShellCommandsRequest.cs
+++ b/ChasmaWebApi/Data/Requests/Shell/ExecuteBatchShellCommandsRequest.cs
@@ -1,0 +1,13 @@
+﻿using ChasmaWebApi.Data.Objects;
+using ChasmaWebApi.Util;
+
+namespace ChasmaWebApi.Data.Requests.Shell
+{
+    public class ExecuteBatchShellCommandsRequest : ChasmaXmlBase
+    {
+        /// <summary>
+        /// Gets or sets the list of batch command entries.
+        /// </summary>
+        public List<BatchCommandEntry> BatchCommands { get; set; } = new();
+    }
+}

--- a/ChasmaWebApi/Data/Responses/Shell/ExecuteBatchShellCommandsResponse.cs
+++ b/ChasmaWebApi/Data/Responses/Shell/ExecuteBatchShellCommandsResponse.cs
@@ -1,0 +1,15 @@
+﻿using ChasmaWebApi.Data.Objects;
+
+namespace ChasmaWebApi.Data.Responses.Shell
+{
+    /// <summary>
+    /// Class representing the response for executing batch shell commands.
+    /// </summary>
+    public class ExecuteBatchShellCommandsResponse : ResponseBase
+    {
+        /// <summary>
+        /// Gets or sets the list of results for each batch command entry.
+        /// </summary>
+        public List<BatchCommandEntryResult> Results { get; set; } = new();
+    }
+}

--- a/chasma-thin-client/src/components/Checkbox.tsx
+++ b/chasma-thin-client/src/components/Checkbox.tsx
@@ -1,0 +1,39 @@
+﻿import React, { useState } from "react";
+import "../css/checkbox.css"
+
+/** Interface defining the members of the checkbox. **/
+interface ICheckboxProps {
+    /** The label of the checkbox. **/
+    label: string;
+
+    /** The action to execute once the box is checked. **/
+    onBoxChecked: (isChecked: boolean) => void;
+}
+
+/**
+ * Initializes a new Checkbox class.
+ * @constructor
+ */
+const Checkbox: React.FC<ICheckboxProps> = (props: ICheckboxProps) => {
+    /** Gets or sets a value indicating whether the box is checked. **/
+    const [checked, setChecked] = useState(false);
+
+    /** Handles the event when the user checks the button. **/
+    const handleOnChangedEvent= (isChecked: boolean) => {
+        setChecked(isChecked);
+        props.onBoxChecked(isChecked);
+    }
+    return (
+        <label className="themed-checkbox">
+            <input
+                type="checkbox"
+                checked={checked}
+                onChange={(e) => handleOnChangedEvent(e.target.checked)}
+            />
+            <span className="checkbox-custom" />
+            <span className="checkbox-label">{props.label}</span>
+        </label>
+    );
+}
+
+export default Checkbox;

--- a/chasma-thin-client/src/components/Dashboard.tsx
+++ b/chasma-thin-client/src/components/Dashboard.tsx
@@ -3,6 +3,7 @@ import '../css/Dashboard.css';
 import HomeTab from "./dashboardTabs/HomeTab";
 import ApiStatusTab from "./dashboardTabs/ApiStatusTab";
 import IncludeRepositoryModal from "./modals/IncludeRepositoryModal";
+import BatchOperationsTab from "./dashboardTabs/BatchOperationsTab";
 
 /**
  * Initializes a new instance of the Dashboard class.
@@ -44,6 +45,12 @@ const Dashboard: React.FC = () => {
                     &#x23FB; API Status
                 </div>
                 <div
+                    className={`tab ${activeTab === "batchOperations" ? "active" : ""}`}
+                    onClick={() => handleTabClick("batchOperations")}
+                >
+                    Batch Operations
+                </div>
+                <div
                     className="tab"
                     onClick={() => setIsIncludingRepos(true)}
                     >
@@ -52,6 +59,7 @@ const Dashboard: React.FC = () => {
             </aside>
             <main className="content">
                 {activeTab === "home" && <HomeTab reposVersion={reposVersion} />}
+                {activeTab === "batchOperations" && <BatchOperationsTab/>}
                 {activeTab === "apiStatus" && <ApiStatusTab/>}
             </main>
             {isIncludingRepos && (

--- a/chasma-thin-client/src/components/dashboardTabs/BatchOperationsTab.tsx
+++ b/chasma-thin-client/src/components/dashboardTabs/BatchOperationsTab.tsx
@@ -1,0 +1,404 @@
+﻿import React, {useEffect, useState} from "react";
+import "../../css/DasboardTab.css";
+import {
+    BatchCommandEntry,
+    BatchCommandEntryResult,
+    ExecuteBatchShellCommandsRequest,
+    ShellClient
+} from "../../API/ChasmaWebApiClient";
+import NotificationModal from "../modals/NotificationModal";
+import {apiBaseUrl} from "../../environmentConstants";
+import {useCacheStore} from "../../managers/CacheManager";
+import Checkbox from "../Checkbox";
+import CustomBatchCommandRow from "./CustomBatchCommandRow";
+import {CommandMode} from "../types/CustomTypes";
+import {isBlankOrUndefined} from "../../stringHelperUtil";
+
+/** The GitCtrl Shell API client. **/
+const shellClient = new ShellClient(apiBaseUrl);
+
+/**
+ * Initializes a new BatchOperationsTab class.
+ * @constructor
+ */
+const BatchOperationsTab: React.FC = () => {
+    /** Cached repositories. **/
+    const repositories = useCacheStore((state) => state.repositories);
+
+    /** Command execution output per repository. **/
+    const [output, setOutput] = useState<{
+        repoName: string | undefined;
+        success: boolean | undefined;
+        message?: string | undefined;
+    }[] | undefined>([]);
+
+    /** Gets or sets the notification **/
+    const [notification, setNotification] = useState<{
+        title: string;
+        message: string | undefined;
+        isError: boolean | undefined;
+        loading?: boolean;
+    } | null>(null);
+
+    /** Batch rows storing repository ID and commands **/
+    const [customBatchRows, setCustomBatchRows] = useState<{
+        id: string;
+        repositoryId?: string;
+        commands: { id: string; first: string; second: string }[];
+    }[]>([{ id: crypto.randomUUID(), repositoryId: undefined, commands: [] }]);
+
+    /** Gets or sets the command execution mode. **/
+    const [commandMode, setCommandMode] = useState<CommandMode>("uniform");
+
+    /** Gets or sets shell commands rows to execute at once. **/
+    const [uniformBatchRows, setUniformBatchRows] = useState<{
+        id: string;
+        repositoryId?: string;
+        commands: { id: string; first: string; second: string }[];
+    }[]>([{ id: crypto.randomUUID(), repositoryId: undefined, commands: [] }]);
+
+    /** Gets or sets a value indicating whether the user is selecting all repositories to execute commands. **/
+    const [isSelectingAllRepositories, setIsSelectingAllRepositories] = useState<boolean>(false);
+
+    /** Adds a new repository row for batch operations. **/
+    const addCustomBatchRow = () => {
+        setCustomBatchRows(prev => [
+            ...prev,
+            { id: crypto.randomUUID(), repositoryId: undefined, commands: [] }
+        ]);
+    };
+
+    /** Deletes a repository batch row. **/
+    const deleteCustomBatchRow = (id: string) => {
+        setCustomBatchRows(prev => prev.filter(row => row.id !== id));
+    };
+
+    /**
+     * Updates a custom batch row.
+     * @param id The row identifier.
+     * @param field "repositoryId" or "commands"
+     * @param value The new value.
+     */
+    const updateCustomBatchRow = (
+        id: string,
+        field: "repositoryId" | "commands",
+        value: string | { id: string; first: string; second: string }[]
+    ) => {
+        setCustomBatchRows(prev =>
+            prev.map(row =>
+                row.id === id ? { ...row, [field]: value } : row
+            )
+        );
+    };
+
+    /** Adds a uniform shell command row to the form. **/
+    const addUniformShellCommandRow = () => {
+        setUniformBatchRows(prev => {
+            const row = prev[0];
+            return [{
+                ...row,
+                commands: [
+                    ...row.commands,
+                    { id: crypto.randomUUID(), first: "", second: "" }
+                ]
+            }];
+        });
+    }
+
+    /**
+     * Deletes a uniform command batch row.
+     * @param cmdId The command identifier.
+     */
+    const deleteUniformShellCommand = (cmdId: string) => {
+        setUniformBatchRows(prev => {
+            const row = prev[0];
+            return [{
+                ...row,
+                commands: row.commands.filter(cmd => cmd.id !== cmdId)
+            }];
+        });
+    };
+
+    /**
+     * Updates a uniform command batch row.
+     * @param cmdId The row identifier.
+     * @param value The new value
+     */
+    const updateUniformShellCommand = (cmdId: string, value: string) => {
+        setUniformBatchRows(prev => {
+            const row = prev[0];
+            return [{
+                ...row,
+                commands: row.commands.map(cmd =>
+                    cmd.id === cmdId ? { ...cmd, first: value } : cmd
+                )
+            }];
+        });
+    };
+
+    /**
+     * Executes a batch git operation for all repositories.
+     */
+    const executeBatchOperation = async () => {
+        setNotification({
+            title: "Executing batch operation...",
+            message: "Running git command on all selected repositories.",
+            isError: false,
+            loading: true,
+        });
+        const request = new ExecuteBatchShellCommandsRequest();
+        request.batchCommands = []
+        if (commandMode === "custom") {
+            customBatchRows.filter(row => row.repositoryId)
+                .forEach(row => {
+                    const entry = new BatchCommandEntry();
+                    entry.repositoryId = row.repositoryId;
+                    entry.commands = row.commands
+                        .map(cmd => cmd.first)
+                        .filter(cmd => cmd.trim() !== "");
+                    request.batchCommands?.push(entry);
+                });
+        }
+        else {
+            const repositoryIds = customBatchRows
+            .filter(i => i.repositoryId !== undefined)
+            .map(row => row.repositoryId);
+            const uniformCommands = uniformBatchRows[0]
+                .commands
+                .map(cmd => cmd.first)
+                .filter(cmd => !isBlankOrUndefined(cmd));
+            request.batchCommands = repositoryIds.map(repoId => {
+                const entry = new BatchCommandEntry();
+                entry.repositoryId = repoId;
+                entry.commands = uniformCommands;
+                return entry;
+            });
+        }
+        setOutput([]);
+        try {
+            const response = await shellClient.executeBatchShellCommands(request);
+            if (response.isErrorResponse) {
+                setNotification({
+                    title: "Batch operation failed!",
+                    message: "Review server logs for more information.",
+                    isError: true,
+                });
+                return;
+            }
+
+            setOutput(
+                response.results?.map((result: BatchCommandEntryResult) => ({
+                    repoName: result.repositoryName,
+                    success: result.isSuccess,
+                    message: result.message,
+                }))
+            );
+            setNotification({
+                title: "Batch operation completed!",
+                message: "Review the output window for details.",
+                isError: false,
+            });
+        } catch (e) {
+            setNotification({
+                title: "Error executing batch shell operation failed!",
+                message: "Review server logs for more information.",
+                isError: true,
+            });
+            console.error(e);
+        }
+    };
+
+    /**
+     * Closes the modal once the user confirms the message
+     */
+    const closeModal = () => {
+        setNotification(null);
+    };
+
+    useEffect(() => {
+        if (isSelectingAllRepositories) {
+            if (!repositories || repositories.length === 0) return;
+
+            setCustomBatchRows(
+                repositories.map(repo => ({
+                    id: crypto.randomUUID(),
+                    repositoryId: repo.id,
+                    commands: []
+                }))
+            );
+        } else {
+            // Reset to one empty row when unchecked
+            setCustomBatchRows([{ id: crypto.randomUUID(), repositoryId: undefined, commands: [] }]);
+        }
+    }, [isSelectingAllRepositories, repositories]);
+
+    return (
+        <>
+            <div className="page">
+                <h1 className="page-title" style={{ textAlign: "center" }}>
+                    Batch Repository Operations
+                </h1>
+                <p className="page-description" style={{ textAlign: "center" }}>
+                    Execute shell commands across all registered repositories at once.
+                </p>
+                <div className="command-mode-toggle">
+                    <div className="command-mode-toggle-inner">
+                        <button
+                            className={`command-mode-button ${commandMode === "uniform" ? "active" : ""}`}
+                            onClick={() => setCommandMode("uniform")}
+                        >
+                            Uniform
+                        </button>
+                        <button
+                            className={`command-mode-button ${commandMode === "custom" ? "active" : ""}`}
+                            onClick={() => setCommandMode("custom")}
+                        >
+                            Custom
+                        </button>
+                    </div>
+                </div>
+                <div style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    marginBottom: "8px",
+                }}>
+                    <Checkbox
+                        label={"Select all repositories"}
+                        onBoxChecked={setIsSelectingAllRepositories}
+                    />
+                    <button
+                        className="submit-button"
+                        hidden={isSelectingAllRepositories}
+                        onClick={addCustomBatchRow}
+                    >
+                        Add Repo
+                    </button>
+                </div>
+                {commandMode === "uniform" && (
+                    <div className="batch-command-row">
+                        <h3 style={{ color: "#00bfff", marginBottom: "8px" }}>
+                            Uniform Shell Commands
+                        </h3>
+                        <div
+                            style={{
+                                display: "flex",
+                                flexDirection: "column",
+                                marginBottom: "10px",
+                            }}
+                        >
+                            {uniformBatchRows[0].commands.map(cmd => (
+                                <div
+                                    key={cmd.id}
+                                    style={{
+                                        display: "flex",
+                                        alignItems: "center",
+                                        gap: "8px",
+                                        marginBottom: "8px",
+                                    }}
+                                >
+                                    <input
+                                        type="text"
+                                        style={{marginTop: "16px"}}
+                                        className="command-input"
+                                        value={cmd.first}
+                                        placeholder="Enter git command (e.g. git pull)"
+                                        onChange={e => updateUniformShellCommand(cmd.id, e.target.value)}
+                                    />
+                                    <button
+                                        className="remove-button"
+                                        onClick={() => deleteUniformShellCommand(cmd.id)}
+                                    >
+                                        −
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                        <button
+                            className="add-button"
+                            type="button"
+                            onClick={addUniformShellCommandRow}
+                        >
+                            +
+                        </button>
+                    </div>
+                )}
+                {customBatchRows.map(row => (
+                    <CustomBatchCommandRow
+                        key={row.id}
+                        id={row.id}
+                        repositoryId={row.repositoryId}
+                        commands={row.commands}
+                        onDelete={deleteCustomBatchRow}
+                        onUpdate={updateCustomBatchRow}
+                        commandMode={commandMode}
+                    />
+                ))}
+                {notification && (
+                    <NotificationModal
+                        title={notification.title}
+                        message={notification.message}
+                        isError={notification.isError}
+                        loading={notification.loading}
+                        onClose={closeModal}
+                    />
+                )}
+                <br />
+                <button
+                    className="submit-button"
+                    type="submit"
+                    onClick={executeBatchOperation}
+                >
+                    Run Batch Git Command
+                </button>
+
+                <div className="batch-page">
+                    <div
+                        style={
+                        {
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                            marginTop: "20px",
+                            marginBottom: "8px",
+                        }
+                    }
+                    >
+                        <h3 style={{ margin: 0 }}>Operation Output</h3>
+                        {output && output.length > 0 && (
+                            <button
+                                className="clear-output-button"
+                                onClick={() => setOutput([])}
+                            >
+                                Clear Output
+                            </button>
+                        )}
+                    </div>
+
+                    <div className="output-window">
+                        {output && output.length === 0 && <p>No operations executed yet.</p>}
+
+                        {output?.map((result, index) => (
+                            <div
+                                key={index}
+                                className={`output-entry ${result.success ? "success" : "failure"}`}
+                            >
+                                <div>
+                                    <strong>{result.repoName}</strong>
+                                    <span className="status-icon"></span>
+                                </div>
+                                {result.message && (
+                                    <div className="output-message">{result.message}</div>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+
+                </div>
+
+            </div>
+        </>
+    );
+};
+
+export default BatchOperationsTab;

--- a/chasma-thin-client/src/components/dashboardTabs/CustomBatchCommandRow.tsx
+++ b/chasma-thin-client/src/components/dashboardTabs/CustomBatchCommandRow.tsx
@@ -1,0 +1,150 @@
+﻿import React from "react";
+import { useCacheStore } from "../../managers/CacheManager";
+import { LocalGitRepository } from "../../API/ChasmaWebApiClient";
+import {CommandMode, Row} from "../types/CustomTypes";
+
+/** Interface for the members on the batch command row. **/
+interface BatchCommandRowProps {
+    /** The row identifier. **/
+    id: string;
+
+    /** Selected repository ID **/
+    repositoryId?: string;
+
+    /** Commands for this row **/
+    commands?: Row[];
+
+    /** The action to perform when the user deletes a row. **/
+    onDelete: (id: string) => void;
+
+    /** The action to perform when the row changes **/
+    onUpdate: (id: string, field: "repositoryId" | "commands", value: string | Row[]) => void;
+
+    /** The current command mode. **/
+    commandMode: CommandMode
+}
+
+/**
+ * A single batch command row that allows selection of a repository and entry of multiple shell commands.
+ * @param id The row identifier.
+ * @param repositoryId The repository identifier.
+ * @param commands The shell commands to execute.
+ * @param onDelete The action to fire when the row is deleted.
+ * @param onUpdate The action to fire when the row is updated.
+ * @param commandMode The current command mode.
+ * @constructor
+ */
+const CustomBatchCommandRow: React.FC<BatchCommandRowProps> = (
+    {
+        id,
+        repositoryId,
+        commands = [],
+        onDelete,
+        onUpdate,
+        commandMode,
+    }) => {
+    /** The cached repositories belonging to the logged-in user. **/
+    const repositories = useCacheStore((state) => state.repositories);
+
+    /** Currently selected repository **/
+    const selectedRepo: LocalGitRepository | null = repositories?.find(r => r.id === repositoryId) || null;
+
+    /**
+     * Handles the event when the repository selection changes.
+     * @param repoId The repository identifier.
+     */
+    const handleRepoChange = (repoId: string) => {
+        onUpdate(id, "repositoryId", repoId);
+    };
+
+    /** Adds a shell command row to the form. **/
+    const addCustomShellCommandRow = () => {
+        const newCommands = [...commands, { id: crypto.randomUUID(), first: "", second: "" }];
+        onUpdate(id, "commands", newCommands);
+    };
+
+    /** Handles custom shell command row changes in the form. **/
+    const handleShellCommandChange = (cmdId: string, value: string) => {
+        const newCommands = commands.map(c => c.id === cmdId ? { ...c, first: value } : c);
+        onUpdate(id, "commands", newCommands);
+    };
+
+    /** Deletes the row with the specified command identifier. **/
+    const deleteShellCommandRow = (cmdId: string) => {
+        const newCommands = commands.filter(c => c.id !== cmdId);
+        onUpdate(id, "commands", newCommands);
+    };
+
+    return (
+        <div className="batch-command-row">
+            <button
+                className="remove-button"
+                title="Remove Repository"
+                onClick={() => onDelete(id)}
+            >
+                x
+            </button>
+            <button
+                className="add-button"
+                type="button"
+                onClick={addCustomShellCommandRow}
+                hidden={commandMode === "uniform"}
+            >
+                +
+            </button>
+            <div className="repo-section">
+                <select
+                    className="repo-dropdown"
+                    value={repositoryId ?? ""}
+                    onChange={(e) => handleRepoChange(e.target.value)}
+                >
+                    <option value="">Select Repository</option>
+                    {repositories?.map(repo => (
+                        <option key={repo.id} value={repo.id}>
+                            {repo.name}
+                        </option>
+                    ))}
+                </select>
+                {selectedRepo && (
+                    <div className="repo-metadata">
+                        <div className="repo-meta-line">
+                            <strong>Repo Title:</strong> {selectedRepo.name}
+                        </div>
+                        <div className="repo-meta-line">
+                            <strong>Repo ID:</strong> {selectedRepo.id}
+                        </div>
+                        <div className="repo-meta-line">
+                            <strong>Repo Owner:</strong> {selectedRepo.owner}
+                        </div>
+                    </div>
+                )}
+            </div>
+            {commandMode === "custom" && (
+                <div className="command-input-wrapper">
+                    {commands.map(cmd => (
+                        <div key={cmd.id}>
+                            <input
+                                type="text"
+                                className="command-input"
+                                value={cmd.first}
+                                onChange={e => handleShellCommandChange(cmd.id, e.target.value)}
+                                placeholder="Enter git command (e.g. git pull)"
+                            />
+                            <button
+                                className="remove-button"
+                                title="Remove shell command"
+                                onClick={() => deleteShellCommandRow(cmd.id)}
+                            >
+                                −
+                            </button>
+                        </div>
+                    ))}
+                    <br />
+                </div>
+            )}
+            <br />
+        </div>
+    );
+};
+
+export default CustomBatchCommandRow;

--- a/chasma-thin-client/src/components/types/CustomTypes.ts
+++ b/chasma-thin-client/src/components/types/CustomTypes.ts
@@ -19,3 +19,6 @@ export type User = {
     username: string | undefined;
     email: string | undefined;
 }
+
+/** The toggle options for selecting commands to execute uniformly or custom. **/
+export type CommandMode = "uniform" | "custom";

--- a/chasma-thin-client/src/css/DasboardTab.css
+++ b/chasma-thin-client/src/css/DasboardTab.css
@@ -17,3 +17,76 @@
     background-color: #00bfff;
     color: #121212;
 }
+
+.batch-command-row {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: 15px;
+    padding: 15px;
+    background-color: #1e1e1e;
+    border-radius: 6px;
+    margin-top: 20px;
+    width: 100%;
+}
+
+.remove-button {
+    background-color: transparent;
+    color: #f44336;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    margin-top: 5px;
+}
+
+.repo-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 250px;
+}
+
+.repo-dropdown {
+    background-color: #121212;
+    color: #ffffff;
+    border: 1px solid #444;
+    padding: 6px;
+    border-radius: 4px;
+    margin-top: 10px;
+}
+
+.repo-metadata label {
+    font-size: 12px;
+    color: #cccccc;
+}
+
+.command-input {
+    flex-grow: 1;
+    background-color: #121212;
+    color: #ffffff;
+    border: 1px solid #444;
+    padding: 8px;
+    border-radius: 4px;
+    margin-top: 2px;
+    width: 100vh;
+}
+
+.add-button {
+    position: absolute;
+    background-color: #28a745;
+    color: #ffffff;
+    border: none;
+    border-radius: 50%;
+    width: 28px;
+    height: 28px;
+    font-size: 18px;
+    cursor: pointer;
+    line-height: 28px;
+    top: -16px;
+    right: -16px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+}
+
+.add-button:hover {
+    background-color: #009acd;
+}

--- a/chasma-thin-client/src/css/Dashboard.css
+++ b/chasma-thin-client/src/css/Dashboard.css
@@ -69,6 +69,12 @@ html, body {
     flex-direction: column;
 }
 
+.batch-page {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
 .page-header {
     position: sticky;
     top: 0;
@@ -407,3 +413,136 @@ html, body {
     margin-bottom: 12px;
     text-align: left;
 }
+.output-window {
+    margin-top: 30px;
+    padding: 15px;
+    background-color: #1e1e1e;
+    border-radius: 6px;
+    color: #ffffff;
+    overflow-y: auto;
+    text-align: left;
+    font-family: Arial, sans-serif;
+    font-size: 14px;
+    flex-grow: 1;
+}
+
+.output-success {
+    color: #28a745;
+    margin-bottom: 8px;
+}
+
+.output-failure {
+    color: #f44336;
+    margin-bottom: 8px;
+}
+
+.output-message {
+    margin-left: 10px;
+    font-size: 0.9em;
+    opacity: 0.85;
+}
+
+.output-entry {
+    display: flex;
+    flex-direction: column;
+    padding: 10px 12px;
+    margin-bottom: 12px;
+    border-left: 4px solid transparent;
+    background-color: #2a2a2a;
+    border-radius: 6px;
+    word-break: break-word;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.output-entry.success {
+    border-left-color: #28a745;
+    background-color: #223322;
+}
+
+.output-entry.failure {
+    border-left-color: #f44336;
+    background-color: #331a1a;
+}
+
+.output-entry strong {
+    font-weight: bold;
+    color: #00bfff;
+    margin-bottom: 4px;
+}
+
+.output-entry .status-icon {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    margin-left: 8px;
+    border-radius: 50%;
+}
+
+.output-entry.success .status-icon {
+    background-color: #28a745;
+}
+
+.output-entry.failure .status-icon {
+    background-color: #f44336;
+}
+
+.output-entry .output-message {
+    font-size: 0.9em;
+    opacity: 0.8;
+    margin-left: 10px;
+    margin-top: 4px;
+    white-space: pre-wrap;
+}
+
+.command-mode-toggle {
+    display: flex;
+    justify-content: center;
+    margin: 12px 0 24px 0;
+}
+
+.command-mode-toggle-inner {
+    display: flex;
+    background-color: #1e1e1e;
+    border: 1px solid #2c2c2c;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+}
+
+.command-mode-button {
+    padding: 8px 24px;
+    font-size: 16px;
+    font-weight: 500;
+    background-color: transparent;
+    color: #ccc;
+    border: none;
+    cursor: pointer;
+    transition: all 0.25s ease;
+}
+
+.command-mode-button:hover {
+    background-color: #2c2c2c;
+    color: #ffffff;
+}
+
+.command-mode-button.active {
+    background-color: #00bfff;
+    color: #121212;
+}
+
+.clear-output-button {
+    padding: 6px 12px;
+    font-size: 14px;
+    background-color: #444;
+    color: #ccc;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.clear-output-button:hover {
+    background-color: #555;
+    color: #fff;
+}
+

--- a/chasma-thin-client/src/css/checkbox.css
+++ b/chasma-thin-client/src/css/checkbox.css
@@ -1,0 +1,58 @@
+﻿.themed-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    user-select: none;
+    font-size: 16px;
+    color: #ddd;
+    margin-bottom: 13px;
+}
+
+.themed-checkbox input {
+    display: none;
+}
+
+.checkbox-custom {
+    width: 18px;
+    height: 18px;
+    border-radius: 4px;
+    background-color: #2c2c2c;
+    border: 1px solid #333;
+    transition: all 0.2s ease;
+    position: relative;
+    box-shadow: inset 0 0 4px rgba(0,0,0,0.6);
+}
+
+.checkbox-custom::after {
+    content: "";
+    position: absolute;
+    left: 5px;
+    top: 1px;
+    width: 5px;
+    height: 10px;
+    border: solid #121212;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.themed-checkbox input:checked + .checkbox-custom {
+    background-color: #00bfff;
+    border-color: #00bfff;
+    box-shadow: 0 0 6px rgba(0, 191, 255, 0.6);
+}
+
+.themed-checkbox input:checked + .checkbox-custom::after {
+    opacity: 1;
+}
+
+.themed-checkbox:hover .checkbox-custom {
+    border-color: #00bfff;
+}
+
+.checkbox-label {
+    font-size: 21px;
+    color: #ccc;
+}


### PR DESCRIPTION
### Description:
This features allows for the user to execute batch commands for multiple repositories.

###  Use Case 1: Uniform
- User selects `Uniform`
- User selects 5 repositories
- User enters `git pull` and clicks run batch command
- All 5 repositories have the `git pull` operation ran on them.

### Use Case 2: Custom
- User selects `Custom`
- User selects 3 repositories (RepoA, RepoB, RepoC)
- User chooses RepoA to execute: `[git submodule update, git status]`
- User chooses RepoB to execute `[git log --oneline]`
- User chooses RepoC to execute `[git commit -m "Updated README.md," git push]`
- The following repositories have the operations ran on them:

1. RepoA -->`[git submodule update, git status]`
2. RepoB -->`[git log --oneline]`
3. RepoC --> `[git commit -m "Updated README.md," git push]`