### PR TITLE
Chasma-143: Added multi-platform support for diffing new files

### DIFF
--- a/ChasmaWebApi/Data/Managers/RepositoryStatusManager.cs
+++ b/ChasmaWebApi/Data/Managers/RepositoryStatusManager.cs
@@ -639,7 +639,8 @@ namespace ChasmaWebApi.Data.Managers
             if (fileStatus == FileStatus.NewInWorkdir)
             {
                 isNewInWorkingDirectory = true;
-                return "git diff --no-index NUL";
+                string emptyFilePlaceholderPath = OperatingSystem.IsWindows() ? "NUL" : "/dev/null";
+                return $"git diff --no-index {emptyFilePlaceholderPath}";
             }
             else if (fileStatus == FileStatus.DeletedFromWorkdir || fileStatus == FileStatus.DeletedFromIndex)
             {


### PR DESCRIPTION
This change allows for users on Windows and UNIX operating systems to be able to get the diff of a new file that is not in the index.