### PR TITLE
Chasma-145: Failed shell execution is properly reflected

### DIFF
--- a/ChasmaWebApi/ChasmaWebOpenApiSpec.json
+++ b/ChasmaWebApi/ChasmaWebOpenApiSpec.json
@@ -1647,15 +1647,30 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "outputMessages": {
+              "results": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ShellCommandResult"
                 }
               }
             }
           }
         ]
+      },
+      "ShellCommandResult": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "executedCommand": {
+            "type": "string"
+          },
+          "outputMessage": {
+            "type": "string"
+          },
+          "isSuccess": {
+            "type": "boolean"
+          }
+        }
       },
       "ExecuteShellCommandRequest": {
         "allOf": [
@@ -1708,6 +1723,9 @@
             "additionalProperties": false,
             "properties": {
               "repositoryName": {
+                "type": "string"
+              },
+              "executedCommand": {
                 "type": "string"
               },
               "isSuccess": {

--- a/ChasmaWebApi/Controllers/ShellController.cs
+++ b/ChasmaWebApi/Controllers/ShellController.cs
@@ -80,8 +80,7 @@ namespace ChasmaWebApi.Controllers
 
             try
             {
-                List<string> outputMessages = shellManager.ExecuteShellCommands(workingDirectory, commands);
-                response.OutputMessages = outputMessages;
+                response.Results = shellManager.ExecuteShellCommands(workingDirectory, commands);
                 logger.LogInformation("Successfully executed shell commands without any exceptions. Sending response.");
                 return Ok(response);
             }
@@ -125,8 +124,7 @@ namespace ChasmaWebApi.Controllers
             try
             {
                 List<BatchCommandEntry> batchCommands = request.BatchCommands;
-                List<BatchCommandEntryResult> results = shellManager.ExecuteShellCommandsInBatch(batchCommands);
-                response.Results = results;
+                response.Results = shellManager.ExecuteShellCommandsInBatch(batchCommands);
                 logger.LogInformation("Successfully executed shell commands without any exceptions. Sending successful response.");
                 return Ok(response);
             }

--- a/ChasmaWebApi/Data/Interfaces/IShellManager.cs
+++ b/ChasmaWebApi/Data/Interfaces/IShellManager.cs
@@ -12,8 +12,8 @@ namespace ChasmaWebApi.Data.Interfaces
         /// </summary>
         /// <param name="workingDirectory">The working directory to execute the commands in.</param>
         /// <param name="shellCommands">The shell commands to execute.</param>
-        /// <returns>The list of output messages from the executed commands.</returns>
-        List<string> ExecuteShellCommands(string workingDirectory, IEnumerable<string> shellCommands);
+        /// <returns>The list of output results from the executed commands.</returns>
+        List<ShellCommandResult> ExecuteShellCommands(string workingDirectory, IEnumerable<string> shellCommands);
 
         /// <summary>
         /// Executes the list of shell commands in batch for multiple working directories.

--- a/ChasmaWebApi/Data/Objects/BatchCommandEntryResult.cs
+++ b/ChasmaWebApi/Data/Objects/BatchCommandEntryResult.cs
@@ -13,6 +13,11 @@ namespace ChasmaWebApi.Data.Objects
         public string RepositoryName { get; set; }
 
         /// <summary>
+        /// Gets or sets the shell command that was executed.
+        /// </summary>
+        public string ExecutedCommand { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the command execution was successful.
         /// </summary>
         public bool IsSuccess { get; set; }

--- a/ChasmaWebApi/Data/Objects/ShellCommandResult.cs
+++ b/ChasmaWebApi/Data/Objects/ShellCommandResult.cs
@@ -1,0 +1,23 @@
+﻿namespace ChasmaWebApi.Data.Objects
+{
+    /// <summary>
+    /// Class representing the result of executing a shell command.
+    /// </summary>
+    public class ShellCommandResult
+    {
+        /// <summary>
+        /// Gets or sets the shell command that was executed.
+        /// </summary>
+        public string ExecutedCommand { get; set; }
+
+        /// <summary>
+        /// Gets or sets the output message from executing the shell command.
+        /// </summary>
+        public string OutputMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the shell command executed successfully.
+        /// </summary>
+        public bool IsSuccess { get; set; }
+    }
+}

--- a/ChasmaWebApi/Data/Responses/Shell/ExecuteShellCommandResponse.cs
+++ b/ChasmaWebApi/Data/Responses/Shell/ExecuteShellCommandResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace ChasmaWebApi.Data.Responses.Shell
+﻿using ChasmaWebApi.Data.Objects;
+
+namespace ChasmaWebApi.Data.Responses.Shell
 {
     /// <summary>
     /// Class representing a response after executing a shell command.
@@ -6,8 +8,8 @@
     public class ExecuteShellCommandResponse : ResponseBase
     {
         /// <summary>
-        /// Gets or sets the output message from the command execution.
+        /// Gets or sets the results from the command execution.
         /// </summary>
-        public List<string> OutputMessages { get; set; } = new();
+        public List<ShellCommandResult> Results { get; set; } = new();
     }
 }

--- a/chasma-thin-client/src/components/dashboardTabs/BatchOperationsTab.tsx
+++ b/chasma-thin-client/src/components/dashboardTabs/BatchOperationsTab.tsx
@@ -28,6 +28,7 @@ const BatchOperationsTab: React.FC = () => {
     /** Command execution output per repository. **/
     const [output, setOutput] = useState<{
         repoName: string | undefined;
+        executedCommand: string | undefined;
         success: boolean | undefined;
         message?: string | undefined;
     }[] | undefined>([]);
@@ -189,6 +190,7 @@ const BatchOperationsTab: React.FC = () => {
             setOutput(
                 response.results?.map((result: BatchCommandEntryResult) => ({
                     repoName: result.repositoryName,
+                    executedCommand: result.executedCommand,
                     success: result.isSuccess,
                     message: result.message,
                 }))
@@ -349,7 +351,7 @@ const BatchOperationsTab: React.FC = () => {
                     type="submit"
                     onClick={executeBatchOperation}
                 >
-                    Run Batch Git Command
+                    Run Batch Git Commands
                 </button>
 
                 <div className="batch-page">
@@ -374,7 +376,6 @@ const BatchOperationsTab: React.FC = () => {
                             </button>
                         )}
                     </div>
-
                     <div className="output-window">
                         {output && output.length === 0 && <p>No operations executed yet.</p>}
 
@@ -384,7 +385,7 @@ const BatchOperationsTab: React.FC = () => {
                                 className={`output-entry ${result.success ? "success" : "failure"}`}
                             >
                                 <div>
-                                    <strong>{result.repoName}</strong>
+                                    <strong>{result.repoName}: {result.executedCommand}</strong>
                                     <span className="status-icon"></span>
                                 </div>
                                 {result.message && (
@@ -393,7 +394,6 @@ const BatchOperationsTab: React.FC = () => {
                             </div>
                         ))}
                     </div>
-
                 </div>
 
             </div>


### PR DESCRIPTION
The changes in this pull request update how shell command execution was presented in the web interface. The new functionality fixes if the command executed successfully, it will show green in the command window. If it fails to execute, it will show red showing it was an error. Examples shown below:

### Specific repository shell command execution
<img width="538" height="529" alt="image" src="https://github.com/user-attachments/assets/5d1afaec-6bd5-4318-8645-dee2557656c4" />

### Batch shell command execution
<img width="2043" height="942" alt="image" src="https://github.com/user-attachments/assets/eaa08845-1bdc-4e2a-ab8f-dd35e98157ee" />
