### PR TITLE
Chasma-172: Implemented hide pull request button

### DIFF
--- a/chasma-thin-client/src/components/modals/PullRequestModal.tsx
+++ b/chasma-thin-client/src/components/modals/PullRequestModal.tsx
@@ -205,7 +205,7 @@ const PullRequestModal: React.FC<IPullRequestProps> = (props: IPullRequestProps)
                     <br/>
                     <div className="modal-actions">
                         <button className="modal-button primary"
-                                disabled={successfullyCreated}
+                                hidden={successfullyCreated}
                                 onClick={handleCreatePrRequest}
                         >
                             Create Pull Request


### PR DESCRIPTION
The `Create Pull Request` button will be hidden after the successful creation of a pull request.