### PR TITLE
Chasma-283: Added logging to merge simulation output

### DIFF
--- a/ChasmaWebApi/ChasmaWebOpenApiSpec.json
+++ b/ChasmaWebApi/ChasmaWebOpenApiSpec.json
@@ -2165,6 +2165,10 @@
           },
           "destinationBranch": {
             "type": "string"
+          },
+          "outputFilePath": {
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/ChasmaWebApi/Core/Services/Simulation/SimulationService.cs
+++ b/ChasmaWebApi/Core/Services/Simulation/SimulationService.cs
@@ -260,7 +260,7 @@ namespace ChasmaWebApi.Core.Services.Simulation
                     Branch sourceBranch = repo.Branches[$"origin/{sourceBranchName}"];
                     if (sourceBranch?.Tip == null)
                     {
-                        DryRunHelper.FailSimulationResult(simulatedMergeResult, $"Source branch {sourceBranchName} does not exist. Merge cannot be performed.");
+                        DryRunHelper.FailSimulationResult(simulatedMergeResult, $"Source branch origin/{sourceBranchName} does not exist. Merge cannot be performed.");
                         dryRunResults.Add(simulatedMergeResult);
                         Logger.LogError("Source branch {sourceBranchName} does not exist. Sending error response.", sourceBranchName);
                         continue;
@@ -269,7 +269,7 @@ namespace ChasmaWebApi.Core.Services.Simulation
                     Branch destinationBranch = repo.Branches[$"origin/{destinationBranchName}"];
                     if (destinationBranch?.Tip == null)
                     {
-                        DryRunHelper.FailSimulationResult(simulatedMergeResult, $"Destination branch {destinationBranchName} does not exist. Merge cannot be performed.");
+                        DryRunHelper.FailSimulationResult(simulatedMergeResult, $"Destination branch origin/{destinationBranchName} does not exist. Merge cannot be performed.");
                         dryRunResults.Add(simulatedMergeResult);
                         Logger.LogError("Destination branch {destinationBranchName} does not exist. Sending error response.", destinationBranchName);
                         continue;
@@ -317,7 +317,27 @@ namespace ChasmaWebApi.Core.Services.Simulation
                         string conflictPhrase = workTreeRepo.Index.Conflicts.Any()
                             ? $" due to conflicts in the following files: \n- {conflictFilesString}\n"
                             : string.Empty;
-                        DryRunHelper.FailSimulationResult(simulatedMergeResult, $"Merge from {sourceBranchName} to {destinationBranchName} cannot be performed{conflictPhrase} Resolve potential conflicts and try merging again.");
+                        string outputFilePath = entry.OutputFilePath;
+                        string logOutputPhrase = "Resolve potential conflicts and try merging again.";
+                        if (!string.IsNullOrEmpty(outputFilePath))
+                        {
+                            logOutputPhrase = $"See the merge conflict result package at {outputFilePath}.";
+                            Commit baseCommit = repo.ObjectDatabase.FindMergeBase(sourceBranch.Tip, destinationBranch.Tip);
+                            MergeConflictResultPackageEntry package = new()
+                            {
+                                OutputPath = outputFilePath,
+                                TimeStamp = DateTimeOffset.Now.ToString("yyyyMMdd_HHmmss"),
+                                WorktreePath = worktreePath,
+                                ConflictingFiles = conflictFiles,
+                                Repository = repository,
+                                SourceBranch = sourceBranch,
+                                DestinationBranch = destinationBranch,
+                                BaseCommit = baseCommit
+                            };
+                            CreateMergeConflictResultsPackage(package);
+                        }
+
+                        DryRunHelper.FailSimulationResult(simulatedMergeResult, $"Merge from {sourceBranchName} to {destinationBranchName} cannot be performed{conflictPhrase} {logOutputPhrase}");
                         simulatedMergeResult.ConflictingFiles = conflictFiles;
                         Logger.LogInformation("Merge simulation of {sourceBranchName} into {destinationBranchName} for repository at {repoPath} resulted in conflicts in the following files: {files}.", sourceBranchName, destinationBranchName, workingDirectory, conflictFilesString);
                     }
@@ -378,6 +398,40 @@ namespace ChasmaWebApi.Core.Services.Simulation
                 MergeStatus.NonFastForward => $"{branchPhrase} Merge successful with a non-fast-forward.",
                 _ => "An unknown merge status was encountered."
             };
+        }
+
+        /// <summary>
+        /// Creates a package containing the results of a merge conflict, including conflicted files, and a README in the specified output directory.
+        /// </summary>
+        /// <param name="package">The merge conflict result package entry containing information about the merge conflict.</param>
+        private static void CreateMergeConflictResultsPackage(MergeConflictResultPackageEntry package)
+        {
+            string outputPath = package.OutputPath;
+            if (!Directory.Exists(outputPath))
+            {
+                Directory.CreateDirectory(outputPath);
+            }
+
+            
+            string mergeSimOutputFolderName = $"merge-sim_{package.Repository.Name}_{package.TimeStamp}";
+            string conflictOutputDirectory = Path.Combine(outputPath, mergeSimOutputFolderName);
+            if (!Directory.Exists(conflictOutputDirectory))
+            {
+                Directory.CreateDirectory(conflictOutputDirectory);
+            }
+
+            foreach (string conflictFile in package.ConflictingFiles)
+            {
+                string relativeFilePath = conflictFile.Replace('/', Path.DirectorySeparatorChar);
+                string sourceFilePath = Path.Combine(package.WorktreePath, relativeFilePath);
+                string extractedFileName = Path.GetFileName(sourceFilePath);
+                string destinationFilePath = Path.Combine(conflictOutputDirectory, extractedFileName);
+                File.Copy(sourceFilePath, destinationFilePath, overwrite: true);
+            }
+
+            string conflictDetectionReportHtmlPath = Path.Combine(conflictOutputDirectory, $"merge-conflict-report.html");
+            string hmtlContent = DryRunHelper.BuildMergeConflictResultPackageHtmlContent(package);
+            File.WriteAllText(conflictDetectionReportHtmlPath, hmtlContent);
         }
 
         #endregion

--- a/ChasmaWebApi/Data/Objects/DryRun/MergeConflictResultPackageEntry.cs
+++ b/ChasmaWebApi/Data/Objects/DryRun/MergeConflictResultPackageEntry.cs
@@ -1,0 +1,51 @@
+﻿using ChasmaWebApi.Data.Objects.Git;
+using LibGit2Sharp;
+
+namespace ChasmaWebApi.Data.Objects.DryRun
+{
+    /// <summary>
+    /// Class representing an entry in the merge conflict result package, containing information about the output path, worktree path, conflicting files, repository, source and destination branches, and the base commit.
+    /// </summary>
+    public class MergeConflictResultPackageEntry
+    {
+        /// <summary>
+        /// Gets or sets the directory where the merge conflict results package is created.
+        /// </summary>
+        public string OutputPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp indicating when the merge conflict results package was created, which can be useful for tracking and auditing purposes.
+        /// </summary>
+        public string TimeStamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the working tree containing the conflicted files.
+        /// </summary>
+        public string WorktreePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the collection of file paths representing files in conflict.
+        /// </summary>
+        public List<string> ConflictingFiles { get; set; } = [];
+
+        /// <summary>
+        /// Gets or sets the local Git repository associated with the merge operation.
+        /// </summary>
+        public LocalGitRepository Repository { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source branch involved in the merge operation.
+        /// </summary>
+        public Branch SourceBranch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the destination branch involved in the merge operation.
+        /// </summary>
+        public Branch DestinationBranch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base commit from which the source and destination branches diverged, which is relevant for understanding the context of the merge conflict.
+        /// </summary>
+        public Commit BaseCommit { get; set; }
+    }
+}

--- a/ChasmaWebApi/Data/Objects/DryRun/MergeSimulationEntry.cs
+++ b/ChasmaWebApi/Data/Objects/DryRun/MergeSimulationEntry.cs
@@ -24,5 +24,10 @@
         /// Gets or sets the destination branch name.
         /// </summary>
         public string DestinationBranch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional output file path where the results of the merge simulation should be stored.
+        /// </summary>
+        public string? OutputFilePath { get; set; }
     }
 }

--- a/ChasmaWebApi/Util/DryRunHelper.cs
+++ b/ChasmaWebApi/Util/DryRunHelper.cs
@@ -1,4 +1,5 @@
 ﻿using ChasmaWebApi.Data.Objects.DryRun;
+using System.Text;
 
 namespace ChasmaWebApi.Util
 {
@@ -16,6 +17,159 @@ namespace ChasmaWebApi.Util
         {
             result.IsSuccessful = false;
             result.ErrorMessage = errorMessage;
+        }
+
+        /// <summary>
+        /// Generates an HTML report summarizing merge conflict details for the specified package.
+        /// </summary>
+        /// <param name="package">The merge conflict result package containing repository, branch, commit, and conflicting file information.</param>
+        /// <returns>An HTML string representing the merge conflict report.</returns>
+        public static string BuildMergeConflictResultPackageHtmlContent(MergeConflictResultPackageEntry package)
+        {
+            StringBuilder conflictingFiles = new();
+            foreach (string file in package.ConflictingFiles)
+            {
+                conflictingFiles.AppendLine($"<li>{file}</li>");
+            }
+
+            return $@"
+            <!DOCTYPE html>
+            <html>
+            <head>
+            <meta charset='utf-8'>
+            <style>
+                body {{font-family: 'Segoe UI', sans-serif;
+                background: #121212;
+                color: #eee;
+                margin: 40px;
+            }}
+
+            h1 {{color: #22d3ee;
+                margin-bottom: 20px;
+                border-bottom: 2px solid #22d3ee;
+                padding-bottom: 6px;
+            }}
+
+            .panel-card {{background: linear-gradient(145deg, #1c1c1c, #242424);
+                border-radius: 12px;
+                padding: 16px;
+                margin-bottom: 20px;
+                box-shadow: 0 4px 12px rgba(0,0,0,0.6);
+            }}
+
+            .panel-card h2 {{color: #22d3ee;
+                margin-bottom: 10px;
+            }}
+
+            .label {{font-weight: 600;
+                color: #aaa;
+            }}
+
+            ul {{margin: 8px 0 0 20px;
+            }}
+
+            .badge {{display: inline-block;
+                padding: 4px 10px;
+                border-radius: 6px;
+                font-size: 12px;
+                font-weight: bold;
+            }}
+
+            .badge.ok {{background: #16a34a;
+                color: white;
+            }}
+
+            .badge.warn {{background: #dc2626;
+                color: white;
+            }}
+
+            .footer {{margin-top: 40px;
+                text-align: center;
+                font-size: 12px;
+                color: #777;
+            }}
+            </style>
+            </head>
+            <body>
+                <h1>Conflict Detection Report</h1>
+                <div class='panel-card'>
+                    <h2>Report Overview</h2>
+                    <div><span class='label'>Repository:</span> {package.Repository?.Name ?? "N/A"}</div>
+                    <div><span class='label'>Timestamp:</span> {package.TimeStamp}</div>
+                <p><span class='label' /> 
+                        <span class='badge warn'>Total Conflicted Files: {package.ConflictingFiles.Count}</span>
+                    </p>
+                </div>
+                <h2>Branch Merge</h2>
+                <div class='panel-card'>
+                    {package.SourceBranch.FriendlyName} ➜ {package.DestinationBranch.FriendlyName}
+                </div>
+                <h2>Commit SHAs</h2>
+                <div class='panel-card'>
+                    <div><span class='label'>Base:</span> {package.BaseCommit?.Sha ?? "N/A"}</div>
+                    <div><span class='label'>Source:</span> {package.SourceBranch.Tip.Sha}</div>
+                    <div><span class='label'>Destination:</span> {package.DestinationBranch.Tip.Sha}</div>
+                </div>
+                <h2>Conflicting Files</h2>
+                <div class='panel-card'>
+                    <ul>
+                        {conflictingFiles}
+                    </ul>
+                </div>
+                <h2>Merge Strategies</h2>
+                <div class='panel-card'>
+                    <p><strong>Abort On Conflict</strong> - Stops immediately when conflicts are detected. Use when:</p>
+                    <ul>
+                        <li>You want strict validation</li>
+                        <li>You prefer manual review for all conflicts</li>
+                    </ul>
+                        <p><strong>Ours Wins</strong> - Always prefers changes from the destination branch (target/current branch) when conflicts occur. Incoming changes are ignored in conflict regions. Use when:</p>
+                    <ul>
+                        <li>The destination branch is considered authoritative (e.g. main)</li>
+                        <li>You want to preserve existing state</li>
+                    </ul>
+                        <p><strong>Theirs Wins</strong> - Always prefers changes from the source branch (incoming branch) when conflicts occur. Destination changes are overwritten in conflict regions. Use when:</p>
+                    <ul>
+                        <li>Incoming branch is trusted or authoritative</li>
+                        <li>You want to fully adopt feature branch changes</li>
+                    </ul>
+                        <p><strong>Manual Resolution Required</strong> - Leaves all conflicts unresolved and marked for manual review. No automatic merging is performed. Use when:</p>
+                    <ul>
+                        <li>You want full visibility into conflicts</li>
+                        <li>You plan to resolve them in an editor or UI</li>
+                    </ul>
+                        <p><strong>Prefer Base When Unchanged</strong> - Uses a 3-way merge heuristic in which if one side hasn't changed from the base commit, the other side wins. Also, if both sides changed the same region, a conflict is created. Use when:</p>
+                    <ul>
+                        <li>You want standard Git-like behavior</li>
+                        <li>You want minimal unnecessary conflicts</li>
+                    </ul>
+                        <p><strong>Last Write Wins</strong> - Resolves conflicts based on timestamps. The most recently modified change overwrites earlier ones. Use when:</p>
+                    <ul>
+                        <li>Working with configuration or non-code data</li>
+                        <li>You prefer `latest update wins` semantics</li>
+                        <li><strong>WARNING:</strong> Can silently overwrite meaningful changes</li>
+                    </ul>
+                        <p><strong>Line-Level Heuristic Merge:</strong> - Performs a line-by-line merge similar to Git’s default behavior of non-overlapping changes are merged automatically and only overlapping edits become conflicts. Use when:</p>
+                    <ul>
+                        <li>You want standard Git-like merging</li>
+                        <li>Working with code files</li>
+                    </ul>
+                        <p><strong>Rule-Based Merge</strong> - Applies user-defined rules to resolve conflicts. Rules can be file-path, directory, or content-based. Use when:</p>
+                    <ul>
+                        <li>You want deterministic enterprise workflows</li>
+                        <li>You need fine-grained control over merge behavior</li>
+                    </ul>
+                        <p><strong>Semantic Merge:</strong> Attempts to understand code structure rather than raw text. Merges based on syntax/AST-level changes instead of line differences. Use when:</p>
+                    <ul>
+                        <li>Working with complex codebases</li>
+                        <li>You want intelligent merging beyond text comparison</li>
+                    </ul>
+                </div>
+                <div class='footer'>
+                    Generated Report on {DateTime.Now:yyyy-MM-dd HH:mm}
+                </div>
+                </body>
+            </html>";
         }
     }
 }

--- a/chasma-thin-client/src/components/dashboardTabs/MultiDryRunSimulationTab.tsx
+++ b/chasma-thin-client/src/components/dashboardTabs/MultiDryRunSimulationTab.tsx
@@ -127,6 +127,7 @@ const MultiDryRunSimulationTab: React.FC = () => {
                 mergeEntry.userId = user?.userId;
                 mergeEntry.sourceBranch = entry.baseBranchToMerge;
                 mergeEntry.destinationBranch = entry.destinationBranchToMerge;
+                mergeEntry.outputFilePath = entry.outputFilePath;
                 mergeSimulationInputs.push(mergeEntry);
             }
         });

--- a/chasma-thin-client/src/components/dashboardTabs/rows/SimulationEntryRow.tsx
+++ b/chasma-thin-client/src/components/dashboardTabs/rows/SimulationEntryRow.tsx
@@ -52,6 +52,9 @@ const SimulationEntryRow: React.FC<ISimulationEntryRow> = (props) => {
     /** Gets or sets the working branch name. **/
     const [baseBranchName, setBaseBranchName] = useState<string | undefined>(undefined);
 
+    /** Gets or sets the simulation output location. */
+    const [simOutputLocation, setSimOutputLocation] = useState<string | undefined>(undefined);
+
     /** The navigation function. **/
     const navigate = useNavigate();
 
@@ -88,6 +91,7 @@ const SimulationEntryRow: React.FC<ISimulationEntryRow> = (props) => {
             branchToAdd: branchToAdd,
             baseBranchToMerge: baseBranchName,
             destinationBranchToMerge: destinationBranch,
+            outputFilePath: simOutputLocation,
         };
         props.onUpdate(entry);
     }
@@ -172,7 +176,8 @@ const SimulationEntryRow: React.FC<ISimulationEntryRow> = (props) => {
         branchToPull,
         branchToAdd,
         baseBranchName,
-        destinationBranch
+        destinationBranch,
+        simOutputLocation
     ]);
 
     return (
@@ -270,6 +275,13 @@ const SimulationEntryRow: React.FC<ISimulationEntryRow> = (props) => {
                                 <option key={branch} value={branch}>{branch}</option>
                             ))}
                         </select>
+                        <input
+                            type="text"
+                            className="modal-input-field"
+                            placeholder="Merge Simulation Output Location (Optional)"
+                            value={simOutputLocation}
+                            onChange={(e) => setSimOutputLocation(e.target.value)}
+                        />
                         <span><code>{baseBranchName}</code> ➜ <code>{destinationBranch}</code></span>
                     </>
                 }

--- a/chasma-thin-client/src/components/modals/MergeModal.tsx
+++ b/chasma-thin-client/src/components/modals/MergeModal.tsx
@@ -51,7 +51,10 @@ const MergeModal: React.FC<IMergeModal> = (props: IMergeModal) => {
     const [workingBranchName, setWorkingBranchName] = useState<string | undefined>(undefined);
 
     /** Gets or sets the remote branches to merge. **/
-    const [branchesList, setBranchesList] = React.useState<string[] | undefined>([]);
+    const [branchesList, setBranchesList] = useState<string[] | undefined>([]);
+
+    /** Gets or sets the merge simulation output location. */
+    const [mergeSimOutputLocation, setMergeSimOutputLocation] = useState<string | undefined>(undefined);
 
     /** The navigation function. **/
     const navigate = useNavigate();
@@ -123,6 +126,7 @@ const MergeModal: React.FC<IMergeModal> = (props: IMergeModal) => {
         mergeEntry.destinationBranch = destinationBranch
         mergeEntry.sourceBranch = workingBranchName;
         mergeEntry.userId = props.userId;
+        mergeEntry.outputFilePath = mergeSimOutputLocation;
         request.mergeEntries = [mergeEntry];
         try {
             const response = await dryRunClient.simulateMergeBranches(request);
@@ -146,6 +150,9 @@ const MergeModal: React.FC<IMergeModal> = (props: IMergeModal) => {
             setSuccessfullyMerged(false);
             const errorNotification = handleApiError(e, navigate, "Error simulating merge operation!", "Error occurred while attempting to simulate merging changes. Check error logs.");
             setNotification(errorNotification);
+        }
+        finally {
+            setMergeSimOutputLocation(undefined);
         }
     }
 
@@ -253,6 +260,16 @@ const MergeModal: React.FC<IMergeModal> = (props: IMergeModal) => {
                                     <option key={branch} value={branch}>{branch}</option>
                                 ))}
                             </select>
+                            <br/>
+                            {props.isSafeMode &&
+                                <input
+                                    type="text"
+                                    className="modal-input-field"
+                                    placeholder="Merge Simulation Output Location (Optional)"
+                                    value={mergeSimOutputLocation}
+                                    onChange={(e) => setMergeSimOutputLocation(e.target.value)}
+                                />
+                            }
                         </div>
                     )}
                     <div className="modal-actions">

--- a/chasma-thin-client/src/components/types/CustomTypes.ts
+++ b/chasma-thin-client/src/components/types/CustomTypes.ts
@@ -39,6 +39,7 @@ export type SimulationEntry = {
     branchToAdd?: string;
     baseBranchToMerge?: string;
     destinationBranchToMerge?: string;
+    outputFilePath?: string;
 }
 
 /** The toggle options for select the global view mode. */


### PR DESCRIPTION
This is for merge simulations. When the user performs a merge simulation and there is conflicts, the system will now create a merge conflict result package and store it wherever the user chooses. The default behavior is also still being maintained of just showing the general conflicting files. Now the user has a more in-depth view as to what is going on and what changes to resolve. It generates a file such as the following: [merge-sim_Chasma_20260503_165616.zip](https://github.com/user-attachments/files/27325312/merge-sim_Chasma_20260503_165616.zip)

