### PR TITLE
Chasma-348: Provided patch for handling type error exceptions on git statuses

### DIFF
--- a/chasma-thin-client/src/components/pages/RepositoryStatusPage.tsx
+++ b/chasma-thin-client/src/components/pages/RepositoryStatusPage.tsx
@@ -219,6 +219,11 @@ const RepositoryStatusPage: React.FC = () => {
             setOpenPullRequests(response.pullRequests);
             setLastUpdated(response.lastUpdated);
         } catch (e) {
+            if (e instanceof TypeError) {
+                // Not going to handle non-API/nswag related exceptions.
+                return;
+            }
+            
             const errorNotification = handleApiError(e, navigate, "Failed to perform 'git status' operation!", "An internal server error has occurred. Review logs.");
             setNotification(errorNotification);
         }


### PR DESCRIPTION
This is unfortunately a workaround for right now that I need to revisit.