### PR TITLE
Chasma-285: Added branch checkout options

### DIFF
--- a/ChasmaWebApi/ChasmaWebOpenApiSpec.json
+++ b/ChasmaWebApi/ChasmaWebOpenApiSpec.json
@@ -2222,11 +2222,38 @@
               "repositoryId": {
                 "type": "string"
               },
+              "userId": {
+                "type": "integer",
+                "format": "int32"
+              },
               "branchName": {
                 "type": "string"
+              },
+              "checkoutMode": {
+                "$ref": "#/components/schemas/BranchCheckoutMode"
+              },
+              "stashMessage": {
+                "type": "string",
+                "nullable": true
               }
             }
           }
+        ]
+      },
+      "BranchCheckoutMode": {
+        "type": "integer",
+        "description": "",
+        "x-enumNames": [
+          "Default",
+          "StashOnly",
+          "KeepChanges",
+          "DiscardAll"
+        ],
+        "enum": [
+          0,
+          1,
+          2,
+          3
         ]
       },
       "GitBranchResponse": {

--- a/ChasmaWebApi/Controllers/BranchController.cs
+++ b/ChasmaWebApi/Controllers/BranchController.cs
@@ -1,6 +1,7 @@
 ﻿using ChasmaWebApi.Core.Interfaces.Control;
 using ChasmaWebApi.Core.Interfaces.Infrastructure;
 using ChasmaWebApi.Data.Objects.Application;
+using ChasmaWebApi.Data.Objects.Git;
 using ChasmaWebApi.Data.Requests.Configuration;
 using ChasmaWebApi.Data.Requests.Status;
 using ChasmaWebApi.Data.Responses.Configuration;
@@ -110,7 +111,7 @@ namespace ChasmaWebApi.Controllers
                 return Ok(response);
             }
 
-            if (request.IsCheckingOutNewBranch && !applicationControlService.TryCheckoutBranch(workingDirectory, branchName, out string checkoutErrorMessage))
+            if (request.IsCheckingOutNewBranch && !applicationControlService.TryCheckoutBranch(workingDirectory, branchName, BranchCheckoutMode.Default, null, user, out string checkoutErrorMessage))
             {
                 logger.LogError("Successfully created branch but failed to checkout to new branch {branchName} for repository {repoId}. Reason: {reason}", branchName, repoId, checkoutErrorMessage);
                 response.IsErrorResponse = true;
@@ -206,9 +207,28 @@ namespace ChasmaWebApi.Controllers
                 return BadRequest(response);
             }
 
+            int userId = request.UserId;
+            if (!cacheManager.Users.TryGetValue(userId, out ApplicationUser user))
+            {
+                logger.LogError("Invalid {request}. User with identifier {id} does not exist. Sending error response.", nameof(GitCheckoutRequest), userId);
+                response.IsErrorResponse = true;
+                response.ErrorMessage = "Invalid request. Could not find user.";
+                return Ok(response);
+            }
+
+            BranchCheckoutMode checkoutMode = request.CheckoutMode;
+            string stashMessage = request.StashMessage;
+            if (checkoutMode == BranchCheckoutMode.StashOnly && string.IsNullOrEmpty(stashMessage))
+            {
+                response.IsErrorResponse = true;
+                response.ErrorMessage = "Stash message must be populated when checkout mode is StashOnly. Cannot checkout branch.";
+                logger.LogError("Checkout mode is StashOnly but stash message is null or empty. Sending error response");
+                return Ok(response);
+            }
+
             try
             {
-                if (!applicationControlService.TryCheckoutBranch(workingDirectory, request.BranchName, out string errorMessage))
+                if (!applicationControlService.TryCheckoutBranch(workingDirectory, request.BranchName, checkoutMode, stashMessage, user, out string errorMessage))
                 {
                     response.IsErrorResponse = true;
                     response.ErrorMessage = $"Failed to checkout branch to repo: {repoId}. {errorMessage}";

--- a/ChasmaWebApi/Core/Interfaces/Control/IApplicationControlService.cs
+++ b/ChasmaWebApi/Core/Interfaces/Control/IApplicationControlService.cs
@@ -79,9 +79,12 @@ namespace ChasmaWebApi.Core.Interfaces.Control
         /// </summary>
         /// <param name="workingDirectory">The working directory of the repository.</param>
         /// <param name="branchName">The branch to checkout.</param>
+        /// <param name="checkoutMode">The branch checkout mode to determine how to handle uncommitted changes when checking out a branch.</param>
+        /// <param name="stashMessage">The stash message to use if stashing is needed when checking out the branch.</param>
+        /// <param name="user">The user performing the branch checkout.</param>
         /// <param name="errorMessage">The error message if there an issue checking out the branch.</param>
         /// <returns>True if the branch is checked out; false otherwise.</returns>
-        bool TryCheckoutBranch(string workingDirectory, string branchName, out string errorMessage);
+        bool TryCheckoutBranch(string workingDirectory, string branchName, BranchCheckoutMode checkoutMode, string? stashMessage, ApplicationUser user, out string errorMessage);
 
         /// <summary>
         /// Gets the list of all branches in the specified repository.

--- a/ChasmaWebApi/Core/Interfaces/Git/IGitBranchService.cs
+++ b/ChasmaWebApi/Core/Interfaces/Git/IGitBranchService.cs
@@ -1,4 +1,7 @@
-﻿namespace ChasmaWebApi.Core.Interfaces.Git
+﻿using ChasmaWebApi.Data.Objects.Application;
+using ChasmaWebApi.Data.Objects.Git;
+
+namespace ChasmaWebApi.Core.Interfaces.Git
 {
     /// <summary>
     /// Interface containing the members on the Git branch service, which is responsible for handling Git branch-level operations such as fetching branches and commits from a repository.
@@ -30,9 +33,12 @@
         /// </summary>
         /// <param name="workingDirectory">The working directory of the repository.</param>
         /// <param name="branchName">The branch to checkout.</param>
+        /// <param name="checkoutMode">The branch checkout mode to determine how to handle uncommitted changes when checking out a branch.</param>
+        /// <param name="stashMessage">The stash message to use if stashing is needed when checking out the branch.</param>
         /// <param name="errorMessage">The error message if there an issue checking out the branch.</param>
+        /// <param name="user">The user performing the branch checkout.</param>
         /// <returns>True if the branch is checked out; false otherwise.</returns>
-        bool TryCheckoutBranch(string workingDirectory, string branchName, out string errorMessage);
+        bool TryCheckoutBranch(string workingDirectory, string branchName, BranchCheckoutMode checkoutMode, string? stashMessage, out string errorMessage, ApplicationUser user = null);
 
         /// <summary>
         /// Gets the list of all branches in the specified repository.

--- a/ChasmaWebApi/Core/Services/Control/ApplicationControlService.cs
+++ b/ChasmaWebApi/Core/Services/Control/ApplicationControlService.cs
@@ -177,9 +177,9 @@ namespace ChasmaWebApi.Core.Services.Control
         }
 
         // <inheritdoc />
-        public bool TryCheckoutBranch(string workingDirectory, string branchName, out string errorMessage)
+        public bool TryCheckoutBranch(string workingDirectory, string branchName, BranchCheckoutMode checkoutMode, string? stashMessage, ApplicationUser user, out string errorMessage)
         {
-            return gitBranchService.TryCheckoutBranch(workingDirectory, branchName, out errorMessage);
+            return gitBranchService.TryCheckoutBranch(workingDirectory, branchName, checkoutMode, stashMessage, out errorMessage, user);
         }
 
         // <inheritdoc />

--- a/ChasmaWebApi/Core/Services/Git/GitBranchService.cs
+++ b/ChasmaWebApi/Core/Services/Git/GitBranchService.cs
@@ -25,9 +25,14 @@ namespace ChasmaWebApi.Core.Services.Git
         private readonly ICacheManager CacheManager;
 
         /// <summary>
+        /// The Git stash service, which is responsible for stashing changes when necessary during Git operations such as checking out a branch with uncommitted changes.
+        /// </summary>
+        private readonly IGitStashService GitStashService;
+
+        /// <summary>
         /// The lock object used for concurrency.
         /// </summary>
-        private readonly object lockObject = new();
+        private readonly Lock lockObject = new();
 
         #region Constructor
 
@@ -36,10 +41,12 @@ namespace ChasmaWebApi.Core.Services.Git
         /// </summary>
         /// <param name="logger">The logger to use for logging diagnostic and operational information within the service.</param>
         /// <param name="cacheManager">The cache manager to use for managing cached data to optimize performance of Git operations.</param>
-        public GitBranchService(ILogger<GitBranchService> logger, ICacheManager cacheManager)
+        /// <param name="stashService">The Git stash service to use for stashing changes when necessary during Git operations.</param>
+        public GitBranchService(ILogger<GitBranchService> logger, ICacheManager cacheManager, IGitStashService stashService)
         {
             Logger = logger;
             CacheManager = cacheManager;
+            GitStashService = stashService;
         }
 
         #endregion
@@ -89,23 +96,52 @@ namespace ChasmaWebApi.Core.Services.Git
         }
 
         // <inheritdoc />
-        public bool TryCheckoutBranch(string workingDirectory, string branchName, out string errorMessage)
+        public bool TryCheckoutBranch(string workingDirectory, string branchName, BranchCheckoutMode checkoutMode, string? stashMessage, out string errorMessage, ApplicationUser user = null)
         {
             errorMessage = string.Empty;
+            StashModifiers stashMode = StashModifiers.Default | StashModifiers.IncludeUntracked;
+            if (user == null)
+            {
+                user = new ApplicationUser()
+                {
+                    Email = "Emryce.bot@emryce.com",
+                    Name = "Emryce-Bot",
+                };
+            }
+
+            if (checkoutMode == BranchCheckoutMode.StashOnly && !GitStashService.TryAddStash(workingDirectory, user, stashMessage, stashMode, out errorMessage))
+            {
+                Logger.LogError("Failed to stash changes for branch checkout for repository at {workingDirectory} with error: {errorMessage}. Sending error response.", workingDirectory, errorMessage);
+                return false;
+            }
+
+            string stashMessageToBePopped = $"Stash for branch checkout of {branchName} at {DateTimeOffset.Now:yyyy-MM-dd HH:mm:ss}";
+            if (checkoutMode == BranchCheckoutMode.KeepChanges && !GitStashService.TryAddStash(workingDirectory, user, stashMessageToBePopped, stashMode, out errorMessage))
+            {
+                Logger.LogError("Failed to stash changes for branch checkout for repository at {workingDirectory} with error: {errorMessage}. Sending error response.", workingDirectory, errorMessage);
+                return false;
+            }
+
+            if (checkoutMode == BranchCheckoutMode.DiscardAll && (!ShellUtility.TryExecuteShellCommand("git restore --staged .", workingDirectory, out errorMessage) || !ShellUtility.TryExecuteShellCommand("git restore .", workingDirectory, out errorMessage)))
+            {
+                Logger.LogError("Failed to discard changes for branch checkout for repository at {workingDirectory} with error: {errorMessage}. Sending error response.", workingDirectory, errorMessage);
+                return false;
+            }
+
             try
             {
                 using Repository repo = new(workingDirectory);
                 Commands.Checkout(repo, branchName);
+                if (checkoutMode == BranchCheckoutMode.KeepChanges && !GitStashService.TryPopStash(workingDirectory, out errorMessage))
+                {
+                    Logger.LogError("Failed to pop stashed changes for branch checkout for repository at {workingDirectory} with error: {errorMessage}. Sending error response.", workingDirectory, errorMessage);
+                    return false;
+                }
+
                 return true;
             }
             catch (Exception e)
             {
-                Logger.LogWarning(e, "Failed to checkout branch {branchName} for repository at {workingDirectory}. Attempting manual checkout.", branchName, workingDirectory);
-                if (ShellUtility.TryExecuteShellCommand($"git checkout {branchName}", workingDirectory, out errorMessage))
-                {
-                    return true;
-                }
-
                 errorMessage = $"Failed to checkout branch {branchName} for repository at {workingDirectory}. Check server logs for more information.";
                 Logger.LogError(e, errorMessage);
                 return false;

--- a/ChasmaWebApi/Core/Services/Git/GitRepositoryService.cs
+++ b/ChasmaWebApi/Core/Services/Git/GitRepositoryService.cs
@@ -574,7 +574,7 @@ namespace ChasmaWebApi.Core.Services.Git
                 {
                     using Repository repo = new(workingDirectory);
                     repo.Reset(ResetMode.Hard);
-                    if (!GitBranchService.TryCheckoutBranch(workingDirectory, repoEntry.BranchName, out errorMessage))
+                    if (!GitBranchService.TryCheckoutBranch(workingDirectory, repoEntry.BranchName, BranchCheckoutMode.Default, null, out errorMessage))
                     {
                         errorMessage = $"Cannot load snapshot for this {repository.GetDisplayName()} because: {errorMessage}.";
                         Logger.LogError(errorMessage);

--- a/ChasmaWebApi/Core/Services/Simulation/SimulationService.cs
+++ b/ChasmaWebApi/Core/Services/Simulation/SimulationService.cs
@@ -119,7 +119,7 @@ namespace ChasmaWebApi.Core.Services.Simulation
                     simulatedPullResult.CommitsToPull = commitEntries;
                     string tempBranchName = $"temp-dry-run-{Guid.NewGuid():N}";
                     tempBranch = repo.CreateBranch(tempBranchName, localBranch.Tip);
-                    if (!GitBranchService.TryCheckoutBranch(workingDirectory, tempBranchName, out string checkoutError))
+                    if (!GitBranchService.TryCheckoutBranch(workingDirectory, tempBranchName, BranchCheckoutMode.Default, null, out string checkoutError))
                     {
                         Logger.LogError("Failed to checkout temporary branch {tempBranch} for repository {repoId} during git pull simulation. Error: {error}", tempBranchName, repoId, checkoutError);
                         DryRunHelper.FailSimulationResult(simulatedPullResult, $"Failed to checkout temporary branch for simulating pull: {checkoutError}");
@@ -144,7 +144,7 @@ namespace ChasmaWebApi.Core.Services.Simulation
                         simulatedPullResult.IsSuccessful = true;
                     }
 
-                    if (!GitBranchService.TryCheckoutBranch(workingDirectory, friendlyBranchName, out string error))
+                    if (!GitBranchService.TryCheckoutBranch(workingDirectory, friendlyBranchName, BranchCheckoutMode.Default, null, out string error))
                     {
                         Logger.LogError("Failed to checkout back to original branch {branchName} for repository {repoId} after git pull simulation. Error: {error}", friendlyBranchName, repoId, error);
                         DryRunHelper.FailSimulationResult(simulatedPullResult, $"Failed to checkout back to original branch after simulating pull: {error}");
@@ -161,7 +161,7 @@ namespace ChasmaWebApi.Core.Services.Simulation
                     Logger.LogError("Failed to simulate git pull for repository {repoId}: {message}.", repoId, e);
                     DryRunHelper.FailSimulationResult(simulatedPullResult, "Pull would fail due to conflicts. Ensure local changes will merge into tracked branch successfully.");
                     dryRunResults.Add(simulatedPullResult);
-                    if (!GitBranchService.TryCheckoutBranch(workingDirectory, friendlyBranchName, out string checkoutError))
+                    if (!GitBranchService.TryCheckoutBranch(workingDirectory, friendlyBranchName, BranchCheckoutMode.Default, null, out string checkoutError))
                     {
                         Logger.LogError("Failed to revert back to {originalBranch} for repository {repoId} during git pull simulation. Error: {error}", friendlyBranchName, repoId, checkoutError);
                         DryRunHelper.FailSimulationResult(simulatedPullResult, $"Failed to revert to {friendlyBranchName} for simulating pull: {checkoutError}");

--- a/ChasmaWebApi/Data/Objects/Git/BranchCheckoutMode.cs
+++ b/ChasmaWebApi/Data/Objects/Git/BranchCheckoutMode.cs
@@ -1,0 +1,28 @@
+﻿namespace ChasmaWebApi.Data.Objects.Git
+{
+    /// <summary>
+    /// The branch checkout mode to determine how to handle uncommitted changes when checking out a branch.
+    /// </summary>
+    public enum BranchCheckoutMode
+    {
+        /// <summary>
+        /// The default branch behavior.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Stashes any uncommitted changes before checking out a new branch.
+        /// </summary>
+        StashOnly,
+
+        /// <summary>
+        /// Stashes any uncommitted changes before checking out a new branch and applies the stashed changes after the checkout is successful.
+        /// </summary>
+        KeepChanges,
+
+        /// <summary>
+        /// Discard all changes before checking out a new branch.
+        /// </summary>
+        DiscardAll,
+    }
+}

--- a/ChasmaWebApi/Data/Requests/Status/GitCheckoutRequest.cs
+++ b/ChasmaWebApi/Data/Requests/Status/GitCheckoutRequest.cs
@@ -1,4 +1,5 @@
-﻿using ChasmaWebApi.Util;
+﻿using ChasmaWebApi.Data.Objects.Git;
+using ChasmaWebApi.Util;
 
 namespace ChasmaWebApi.Data.Requests.Status
 {
@@ -13,8 +14,23 @@ namespace ChasmaWebApi.Data.Requests.Status
         public string RepositoryId { get; set; }
 
         /// <summary>
+        /// Gets or sets the identifier of the user performing the checkout operation.
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
         /// Gets or sets the name of the branch to checkout.
         /// </summary>
         public string BranchName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the branch checkout mode to determine how to handle uncommitted changes when checking out a branch.
+        /// </summary>
+        public BranchCheckoutMode CheckoutMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stash message to use if stashing is necessary during the checkouit process.
+        /// </summary>
+        public string? StashMessage { get; set; }
     }
 }

--- a/chasma-thin-client/src/components/modals/CheckoutModal.tsx
+++ b/chasma-thin-client/src/components/modals/CheckoutModal.tsx
@@ -1,9 +1,10 @@
-﻿import {GitBranchRequest, GitCheckoutRequest} from "../../API/ChasmaWebApiClient";
-import React, {useEffect, useState} from "react";
-import {branchClient} from "../../managers/ApiClientManager";
+﻿import { BranchCheckoutMode, GitBranchRequest, GitCheckoutRequest } from "../../API/ChasmaWebApiClient";
+import React, { useEffect, useState } from "react";
+import { branchClient } from "../../managers/ApiClientManager";
 import { useNavigate } from "react-router-dom";
 import { useCacheStore } from "../../managers/CacheManager";
 import { handleApiError } from "../../managers/TransactionHandlerManager";
+import Checkbox from "../Checkbox";
 
 /**
  * The members of the checkout modal.
@@ -46,14 +47,32 @@ const CheckoutModal: React.FC<ICheckoutModalProps> = (props: ICheckoutModalProps
     /** The navigation function. **/
     const navigate = useNavigate();
 
-   /** Sets the notification modal. */
-   const setNotification = useCacheStore(state => state.setNotification);
+    /** Sets the notification modal. */
+    const setNotification = useCacheStore(state => state.setNotification);
+
+    /** Gets the logged-in user. */
+    const user = useCacheStore(state => state.user);
+
+    /** Gets or sets the branch checkout mode. */
+    const [branchCheckoutMode, setBranchCheckoutMode] = useState<BranchCheckoutMode>(BranchCheckoutMode.Default);
+
+    /** Gets or sets the stash message the user has input. **/
+    const [stashMessage, setStashMessage] = useState<string | undefined>(undefined);
 
     /** Handles the event when the user requests to check out changes. **/
     const handleCheckoutChangesRequest = async () => {
+        if (branchCheckoutMode === BranchCheckoutMode.StashOnly && (!stashMessage || stashMessage.length === 0)) {
+            setErrorMessage("Must include a stash message.");
+            setTitle("Could not check out branch!");
+            return;
+        }
+
         const request = new GitCheckoutRequest();
         request.repositoryId = props.repositoryId;
         request.branchName = branchName;
+        request.userId = user?.userId;
+        request.checkoutMode = branchCheckoutMode;
+        request.stashMessage = stashMessage;
         try {
             const response = await branchClient.checkoutBranch(request);
             if (response.isErrorResponse) {
@@ -168,26 +187,63 @@ const CheckoutModal: React.FC<ICheckoutModalProps> = (props: ICheckoutModalProps
                     </div>
                     <h2 className="modal-title">{title}</h2>
                     {errorMessage && <h3 className="modal-message">{errorMessage}</h3>}
+                    <div style={{ justifySelf: "left", display: "grid", rowGap: "8px", marginBottom: "8px" }}>
+                        <Checkbox
+                            label={"Default"}
+                            onBoxChecked={() => setBranchCheckoutMode(BranchCheckoutMode.Default)}
+                            checked={branchCheckoutMode === BranchCheckoutMode.Default}
+                            tooltip="The default git checkout behavior."
+                        />
+                        <Checkbox
+                            label={"Stash Only"}
+                            onBoxChecked={() => setBranchCheckoutMode(BranchCheckoutMode.StashOnly)}
+                            checked={branchCheckoutMode === BranchCheckoutMode.StashOnly}
+                            tooltip="Save your current workspace and start fresh."
+                        />
+                        <Checkbox
+                            label={"Keep Changes"}
+                            onBoxChecked={() => setBranchCheckoutMode(BranchCheckoutMode.KeepChanges)}
+                            checked={branchCheckoutMode === BranchCheckoutMode.KeepChanges}
+                            tooltip="Transfer your changes from your current branch to the branch you're switching to."
+                        />
+                        <Checkbox
+                            label={"Discard Changes"}
+                            onBoxChecked={() => setBranchCheckoutMode(BranchCheckoutMode.DiscardAll)}
+                            checked={branchCheckoutMode === BranchCheckoutMode.DiscardAll}
+                            tooltip="Discard all your current changes in your workspace."
+                        />
+                    </div>
+                    <br />
                     {branchesList && branchesList.length > 0 && (
                         <select value={branchName}
-                                onChange={(e) => setBranchName(e.target.value)}
-                                className="modal-input-field"
+                            onChange={(e) => setBranchName(e.target.value)}
+                            className="modal-input-field"
                         >
                             {branchesList.map((branch) => (
                                 <option key={branch} value={branch}>{branch}</option>
                             ))}
                         </select>
                     )}
-                    <br/>
+                    <br />
+                    {branchCheckoutMode === BranchCheckoutMode.StashOnly &&
+                        <>
+                            <input className="modal-input-field"
+                                placeholder="Enter Stash Title:"
+                                value={stashMessage}
+                                onChange={(e) => setStashMessage(e.target.value)} />
+
+                            <br />
+                        </>
+                    }
                     <div className="modal-actions">
                         <button className="modal-button primary"
-                                disabled={checkoutRequestSent}
-                                onClick={handleCheckoutChangesRequest}
+                            disabled={checkoutRequestSent}
+                            onClick={handleCheckoutChangesRequest}
                         >
                             Checkout
                         </button>
                         <button className="modal-button secondary"
-                                onClick={props.onClose}
+                            onClick={props.onClose}
                         >
                             Close
                         </button>

--- a/chasma-thin-client/src/components/pages/RepositoryStatusPage.tsx
+++ b/chasma-thin-client/src/components/pages/RepositoryStatusPage.tsx
@@ -185,6 +185,9 @@ const RepositoryStatusPage: React.FC = () => {
     /** Gets or sets a value indicating whether the remote actions tab is open. */
     const [isRemoteOptionsOpen, setIsRemoteOptionsOpen] = useState<boolean>(false);
 
+    /** Gets or sets a value indicating whether the stashes and automation actions tab is open. */
+    const [isStashesAndAutomationOptionsOpen, setIsStashesAndAutomationOptionsOpen] = useState<boolean>(false);
+
     /** Load git status every 2.5s **/
     useEffect(() => {
         if (!repoId) return;
@@ -582,21 +585,33 @@ const RepositoryStatusPage: React.FC = () => {
                 >
                     Repo Status 📊
                 </div>
-                {!isSafeMode &&
-                    <>
-                        <div
-                            className={`tab ${activeTab === "stashes" ? "active" : ""}`}
-                            onClick={() => handleTabClick("stashes")}
-                        >
-                            Stashes🗄️
-                        </div>
-                        <div
-                            className={`tab ${activeTab === "shell" ? "active" : ""}`}
-                            onClick={() => handleTabClick("shell")}>
-                            Custom Shell Commands🖥️
-                        </div>
-                    </>
-                }
+
+                <div
+                    className="sidebar-section-header"
+                    onClick={() => setIsStashesAndAutomationOptionsOpen(!isStashesAndAutomationOptionsOpen)}
+                >
+                    <span>Stashes & Automation</span>
+                    <span className={`arrow ${isStashesAndAutomationOptionsOpen ? "open" : ""}`}>▶</span>
+                </div>
+                {isStashesAndAutomationOptionsOpen && (
+                    <div className="sidebar-section-content">
+                        {!isSafeMode &&
+                            <>
+                                <div
+                                    className={`tab ${activeTab === "stashes" ? "active" : ""}`}
+                                    onClick={() => handleTabClick("stashes")}
+                                >
+                                    Stashes🗄️
+                                </div>
+                                <div
+                                    className={`tab ${activeTab === "shell" ? "active" : ""}`}
+                                    onClick={() => handleTabClick("shell")}>
+                                    Custom Shell Commands🖥️
+                                </div>
+                            </>
+                        }
+                    </div>
+                )}
                 <div
                     className="sidebar-section-header"
                     onClick={() => setIsRepoActionsOpen(!isRepoActionsOpen)}

--- a/chasma-thin-client/src/styles/components/apiStatus.css
+++ b/chasma-thin-client/src/styles/components/apiStatus.css
@@ -1,31 +1,23 @@
-﻿/* Symmetrical Stacked Framework Configuration */
-.status-dashboard-grid {
+﻿.status-dashboard-grid {
     display: flex;
-    flex-direction: column;       /* Aligns your cards vertically on top of each other */
-    align-items: center;          /* Centers the stack cleanly within your primary screen view */
+    flex-direction: column;
+    align-items: center;
     width: 100%;
     max-width: 100%;
 }
 
-/* ==========================================================================
-   New Horizontal Separator Line Style
-   ========================================================================== */
 .card-spacer-line {
     width: 100%;
-    max-width: 520px;             /* Perfectly matches the width of the cards above and below */
+    max-width: 520px;
     border: 0;
     height: 1px;
-    background: #1e293b;          /* Matches your original subtle card border color scheme */
-    margin: 24px 0;               /* Ensures completely uniform, equal padding between elements */
+    background: #1e293b;
+    margin: 24px 0;
 }
-
-/* ==========================================================================
-   Top Module: Server Status Card Parameters (Preserved)
-   ========================================================================= */
 
 .api-status-card {
     width: 100%;
-    max-width: 520px;             /* Establishes your foundational layout size target */
+    max-width: 520px;
 }
 
 .card-header {
@@ -108,13 +100,9 @@
     color: #9ca3af;
 }
 
-/* ==========================================================================
-   Bottom Module: Power Options Card Parameters (Symmetrically Matched)
-   ========================================================================= */
-
 .power-config-card {
     width: 100%;
-    max-width: 520px;             /* Mirrors the exact sizing block limits of the Server card */
+    max-width: 520px;
     background: transparent;
 }
 


### PR DESCRIPTION
The user can do the following when switching branches now to make it easier and cut the intermediate steps:
- Default : normal checkout behavior
- Stash Only: Stash the changes only
- Keep Changes: Stash and apply changes on new branch
- Discard All: discard all changes before changing branches